### PR TITLE
Fixes

### DIFF
--- a/roundware/notifications/__init__.py
+++ b/roundware/notifications/__init__.py
@@ -1,41 +1,60 @@
+import logging
+import datetime
+from django.conf import settings
 from django.db.models.signals import post_save, post_delete
 from roundware.notifications.models import ActionNotification, ENABLED_MODELS
 
 __author__ = 'jule'
+logger = logging.getLogger("notifications")
 
 def send_notifications_add(sender, instance, created, **kwargs):
-    print "add"
     if not created:
         return
+    logger.info("caught add")
     object_string = sender._meta.object_name.lower()
+    logger.info("%s %s", object_string, instance.id)
     objects = [i[0] for i in ENABLED_MODELS if i[1].lower() == object_string]
     if objects:
         object_int = objects[0]
-        notifications = ActionNotification.objects.filter(notification__model=object_int, action=0)
+        date_diff = datetime.datetime.now() - datetime.timedelta(seconds=getattr(settings, "NOTIFICATIONS_TIME_BETWEEN", 30))
+        notifications = ActionNotification.objects.filter(notification__model = object_int,
+                                                          action = 0,
+                                                          last_sent_time__lt=date_diff
+                                                          )
+        logger.info("%s", notifications)
         for n in notifications:
-            n.notify()
+            n.notify(ref=instance.pk)
 
 def send_notifications_edit(sender, instance, created, **kwargs):
-    print "edit"
     if created:
         return
-
+    logger.info("caught edit")
     object_string = sender._meta.object_name.lower()
+    logger.info("%s %s", object_string, instance.id)
     objects = [i[0] for i in ENABLED_MODELS if i[1].lower() == object_string]
     if objects:
         object_int = objects[0]
-        notifications = ActionNotification.objects.filter(notification__model=object_int, action=1)
+        date_diff = datetime.datetime.now() - datetime.timedelta(seconds=getattr(settings, "NOTIFICATIONS_TIME_BETWEEN", 30))
+        notifications = ActionNotification.objects.filter(notification__model = object_int,
+                                                          action = 1,
+                                                          last_sent_time__lt=date_diff
+                                                         )
+        logger.info("%s", notifications)
         for n in notifications:
-            n.notify()
+            n.notify(ref=instance.pk)
 
 def send_notifications_delete(sender, instance, **kwargs):
+    logger.info("caught delete")
     object_string = sender._meta.object_name.lower()
+    logger.info("%s %s", object_string, instance.id)
     objects = [i[0] for i in ENABLED_MODELS if i[1].lower() == object_string]
     if objects:
         object_int = objects[0]
-        notifications = ActionNotification.objects.filter(notification__model=object_int, action=2)
+        notifications = ActionNotification.objects.filter(notification__model = object_int,
+                                                          action = 2)
+        logger.info("%s", notifications)
         for n in notifications:
-            n.notify()
+            n.notify(ref=instance.pk)
 
 post_save.connect(send_notifications_add)
 post_delete.connect(send_notifications_delete)

--- a/roundware/notifications/admin.py
+++ b/roundware/notifications/admin.py
@@ -4,6 +4,7 @@ from roundware.notifications.models import ModelNotification, ActionNotification
 class ActionNotificationInline(admin.TabularInline):
     model = ActionNotification
     filter_horizontal = ['who']
+    fields = ('action', 'subject', 'message', 'who')
 
 class ModelNotificationAdmin(admin.ModelAdmin):
     inlines = [ActionNotificationInline]


### PR DESCRIPTION
I made the fixes we discussed.

1) Notifications only get sent once when changes are made within 300 minutes of each other.
This amount can be changed by setting the "NOTIFICATION_TIME_BETWEEN" variable in your settings.py file (it defaults to 300 seconds)

2) the URL added the bottom of the emails points to the correct Asset

3) the subject is correctly added to the email

4) there is some basic debug logging, enabled the 'notifications' logger in your settings.py LOGGING dictionary to direct to a 'handler' of your choosing.

You will need to recreate the notification tables in your database. You can do this by running

$ python manage.py sqlreset notifications

this will give you a list of SQL commands that will remove the notifications tables and re-add them with the new columns.

$ mysql -uround -pround roundware < [output of above command] will run this on the database.

You can do the whole thing at once with the following command:

$ python manage.py sqlreset notifications | mysql -u round -p round roundware

ping me if you have any questions.
