### PR TITLE
Fixes for trac #379, trac #395

### DIFF
--- a/roundware/rw/views.py
+++ b/roundware/rw/views.py
@@ -28,7 +28,7 @@ from roundwared import server
 
 
 def main(request):
-    return HttpResponse(json.dumps(catch_errors(request), sort_keys=True, indent=4), mimetype='application/json')
+    return HttpResponse(json.dumps(catch_errors(request), sort_keys=True, indent=4, ensure_ascii=False), mimetype='application/json')
 
 
 def catch_errors(request):


### PR DESCRIPTION
Set json.dumps in rw/views.py to allow non-ascii return values.

Fixes character encoding issues with latin extended character sets (and others in the future)
from get_available_assets, and any other JSON dumps.
(note that when viewing results in a browser that hasn't been set to view utf-8,
many browsers when viewing an application/json result will still show funny characters).

Allow passing multiple envelope_ids to get_available_assets.  Show unique
Assets from those Envelopes only, ignoring other filter criteria.

Return language code for each Asset in result from get_available_assets.
