### PR TITLE
Trac 424 completion: Handle field file adding asset to envelope

### DIFF
--- a/roundwared/server.py
+++ b/roundwared/server.py
@@ -526,6 +526,7 @@ def add_asset_to_envelope(request):
                                      volume=1.0,
                                      language=session.language,
                                      project = session.project)
+                asset.file.name = fn
                 asset.save()
                 for t in tagset:
                     asset.tags.add(t)


### PR DESCRIPTION
Add file.name when adding Asset in add_asset_to_envelope so we can get file handle from asset.file
Reverts deletion of  project key assignment in get_available_assets
