### PR TITLE
Performance optimizations Trac 415

### DIFF
--- a/INSTALL-prereqs
+++ b/INSTALL-prereqs
@@ -1,4 +1,4 @@
-sudo apt-get install python-mysqldb python-configobj mysql-server icecast2 ffmpeg apache2 pacpl gstreamer0.10-gnomevfs python-dbus libapache2-mod-fastcgi python-gst0.10 python-django python-flup gstreamer0.10-ffmpeg gstreamer0.10-fluendo-mp3 gstreamer0.10-plugins-base gstreamer0.10-plugins-bad gstreamer0.10-plugins-good gstreamer0.10-plugins-bad-multiverse gstreamer0.10-plugins-ugly libavcodec-extra-53 python-pip gstreamer-tools python-setuptools
+sudo apt-get install python-mysqldb python-configobj mysql-server icecast2 ffmpeg apache2 pacpl gstreamer0.10-gnomevfs python-dbus libapache2-mod-fastcgi python-gst0.10 python-django python-flup gstreamer0.10-ffmpeg gstreamer0.10-fluendo-mp3 gstreamer0.10-plugins-base gstreamer0.10-plugins-bad gstreamer0.10-plugins-good gstreamer0.10-plugins-bad-multiverse gstreamer0.10-plugins-ugly libavcodec-extra-53 python-pip gstreamer-tools python-setuptools python-profiler
 
 sudo a2enmod rewrite
 # django apps

--- a/bin/streamscript
+++ b/bin/streamscript
@@ -1,16 +1,14 @@
 #!/usr/bin/env python
 
-import threading
 import logging
 import sys
-import os
 import traceback
 from roundwared import settings
 from roundwared import daemon
 from roundwared import roundgetopt
-from roundwared import stream
-from roundwared import settings
+from roundwared.stream import RoundStream
 from roundwared import rounddbus
+# from memory_profiler import profile
 
 
 def listofint(s):
@@ -20,7 +18,7 @@ options_data = [
 	#(name,			type,		default)
 	("session_id",		int),
 	("foreground",),
-        ("project_id",		int,	0),
+    ("project_id",		int,	0),
 	#("subcategoryid",	listofint,	[]),
 	#("questionid",		listofint,	[]),
 	#("usertypeid",		listofint,	[]),
@@ -34,6 +32,7 @@ options_data = [
         ("audio_stream_bitrate", int, 128),
 ]
 
+# @profile
 def main ():
 	opts = roundgetopt.getopts(options_data)
 	if opts.has_key('configfile'):
@@ -69,7 +68,7 @@ def initialize_logging(foreground):
 def start_stream (sessionid, audio_format, request):
 	try:
 		logging.info("Starting stream " + str(sessionid))
-		current_stream = stream.RoundStream(
+		current_stream = RoundStream(
 			sessionid, audio_format, request)
 		rounddbus.add_stream_signal_receiver(current_stream)
 		current_stream.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-# This file contains all the packages to be installed through pip along with the latest, tested, version number.
-# to run, simple execute 'pip install -r requirements.txt'
 Django==1.3.4
 South==0.7.6
 configobj==4.7.2
 django-chartit==0.1
 django-guardian==1.0.4
 psutil==0.7.1
+django-cache-utils==0.7.2
+django-profiler==1.1

--- a/roundware/settings.py
+++ b/roundware/settings.py
@@ -39,6 +39,10 @@ EMAIL_HOST_USER = 'email@gmail.com'
 EMAIL_HOST_PASSWORD = 'password'
 EMAIL_PORT = 587
 EMAIL_USE_TLS = True
+
+LISTEN_UIMODE = "listen"
+SPEAK_UIMODE = "speak"
+
 ######## END ROUNDWARE SPECIFIC SETTINGS #########
 
 #change this to reflect your environment
@@ -180,7 +184,7 @@ LOGGING = {
         'mail_admins': {
             'level': 'ERROR',
             'class': 'django.utils.log.AdminEmailHandler'
-        }
+        },
     },
     'loggers': {
         'django.request': {
@@ -188,8 +192,53 @@ LOGGING = {
             'level': 'ERROR',
             'propagate': True,
         },
+    },
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
+        },
+        'simple': {
+            'format': '%(levelname)s %(message)s'
+        },
+    },
+}
+
+# PROFILING using django-profiler
+if DEBUG:
+    PROFILING_SQL_QUERIES = True
+    LOGGING['handlers'].update({
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose'
+        },
+        'profile_logfile': {
+            'filename': '/var/log/rwprofiling',
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'formatter': 'verbose'
+        },        
+    })
+
+    LOGGING['loggers'].update({
+         'profiling': {
+            'level': 'DEBUG',
+            'handlers': ['console','profile_logfile'],
+            'propagate': False,
+         },   
+    })       
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '/var/tmp/django_cache',
+        'TIMEOUT': 60,
+        'OPTIONS': {
+            'MAX_ENTRIES': 1000
+        }
     }
 }
+
 
 # Load the local settings file
 try:

--- a/roundwared/composition.py
+++ b/roundwared/composition.py
@@ -11,12 +11,10 @@ pygst.require("0.10")
 import gst
 import random
 import logging
-import sys
 import os
 from roundwared import roundfilesrc
 from roundwared import settings
 from roundwared import db
-from roundware.rw import models
 
 STATE_PLAYING = 0
 STATE_DEAD_AIR = 1

--- a/roundwared/gpsmixer.py
+++ b/roundwared/gpsmixer.py
@@ -8,7 +8,6 @@ import math
 import httplib
 import urlparse
 from roundwared import gnomevfsmp3src
-from roundwared import settings
 
 
 class GPSMixer (gst.Bin):

--- a/roundwared/icecast2.py
+++ b/roundwared/icecast2.py
@@ -1,6 +1,5 @@
 import libxml2
 import urllib2
-import os
 import logging
 import pycurl
 

--- a/roundwared/recording_collection.py
+++ b/roundwared/recording_collection.py
@@ -3,6 +3,7 @@
 import logging
 import random
 import threading
+from profiling import profile
 from roundwared import gpsmixer
 from roundware.rw import models
 from roundwared import db
@@ -28,6 +29,7 @@ class RecordingCollection:
         self.update_request(self.request)
 
     # Updates the request stored in the collection.
+    # @profile(stats=True)
     def update_request(self, request):
         logging.debug("update_request")
         self.lock.acquire()
@@ -43,6 +45,7 @@ class RecordingCollection:
         self.lock.release()
 
     # Gets a new recording to play.
+    # @profile(stats=True)
     def get_recording(self):
         logging.debug("Recording Collection: Getting a recording from the bucket.")
         self.lock.acquire()

--- a/roundwared/settings.py
+++ b/roundwared/settings.py
@@ -28,6 +28,8 @@ configstring = """
     heartbeat_timeout   = integer(1, 3600, default=30)
     recording_repeat_count  = integer(0, default = 2)
     recording_radius    = integer(0, 6378100, default=16)
+    external_host_name_without_port = string(default=rw.externalhost.com)
+    demo_stream_cpu_limit = float(0.0,100.0,default=50.0)
 """
 
 

--- a/roundwared/stream.py
+++ b/roundwared/stream.py
@@ -8,7 +8,7 @@ import time
 from roundwared import settings
 from roundwared import composition
 from roundwared import icecast2
-from roundwared import server
+from roundwared.server import icecast_mount_point
 from roundwared import gpsmixer
 from roundwared import recording_collection
 from roundware.rw import models
@@ -26,7 +26,7 @@ class RoundStream:
         self.bitrate = request["audio_stream_bitrate"]
         logging.debug("Roundstream init: bitrate: {0}".format(self.bitrate))
         logging.debug("Roundstream init: getting session id")
-        session = models.Session.objects.get(id=sessionid)
+        session = models.Session.objects.select_related('project').get(id=sessionid)
         logging.debug("Roundstream init: got session, getting project radius")
         self.radius = session.project.recording_radius
         self.ordering = session.project.ordering
@@ -246,7 +246,7 @@ class RoundStream:
 
     def is_anyone_listening(self):
         listeners = self.icecast_admin.get_client_count(
-            server.icecast_mount_point(
+            icecast_mount_point(
                 self.sessionid, self.audio_format))
         #logging.debug("Number of listeners: " + str(listeners))
         if self.last_listener_count == 0 and listeners == 0:
@@ -293,7 +293,7 @@ class RoundStreamSink (gst.Bin):
         #shout2send.set_property("username", "source")
         #shout2send.set_property("password", "roundice")
         shout2send.set_property("mount",
-            server.icecast_mount_point(sessionid, audio_format))
+            icecast_mount_point(sessionid, audio_format))
         #shout2send.set_property("streamname","initial name")
         #self.add(capsfilter, volume, self.taginjector, shout2send)
         self.add(capsfilter, volume, shout2send)


### PR DESCRIPTION
See http://www.roundware.org/trac/ticket/415

Implemented select_related where possible throughout.  Added filesytem caching to /var/tmp/django-cache, for a few methods.  Refactored filter_tags_for_request.  Cleaned up unused imports.    

Pre- and post-profiling showed drastically reduced SQL queries throughout and even reduced numbef of calls to expensive get_recordings and filter_tags_for_request.

Also performed  memory profiling on /bin/streamscript but didn't identify any ways to reduce much of any memory usage.

You'll need to rerun INSTALL-prereqs after you merge this.
