### PR TITLE
Downgrade tastypie to fix: :0001_initial TypeError: type() argument 1 must be string, not unicode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -141,12 +141,8 @@ chown $USERNAME:$USERNAME -R $WWW_PATH
 # Initialize database with syncdb and default_auth_data.json
 $CODE_PATH/roundware/manage.py syncdb --noinput
 $CODE_PATH/roundware/manage.py loaddata $CODE_PATH/roundware/fixtures/default_auth_data.json
-$CODE_PATH/roundware/manage.py migrate roundware.rw
-$CODE_PATH/roundware/manage.py migrate roundware.notifications
-$CODE_PATH/roundware/manage.py migrate guardian
+$CODE_PATH/roundware/manage.py migrate
 mysql -uroot -p$MYSQL_ROOT roundware < $CODE_PATH/files/rw_base.sql
-
-# TODO: Tastypie migration?
 
 # Setup apache
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -15,7 +15,7 @@ django-floppyforms==1.1
 django-extra-views==0.6.3
 django-formset-js==0.4.0
 django-sortedm2m==0.6.1
-django-tastypie==0.11.0
+django-tastypie==0.9.16
 --allow-external django-ajax-filtered-fields
 --allow-unverified django-ajax-filtered-fields
 django-ajax-filtered-fields==0.5


### PR DESCRIPTION
The tastypie migration doesnt work due to a bug(https://github.com/toastdriven/django-tastypie/pull/997) in tastypie. This downgrades tastypie to a known working version.
