### PR TITLE
Convert icecast2.py to use Requests library instead of pycurl and urllib2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,10 @@ chown $USERNAME:$USERNAME /home/$USERNAME/runserver.sh
 # Create a symbolic link to the main roundware directory
 ln -sfn $WWW_PATH /home/$USERNAME/www
 
+
+# Install python-software-properties to add add-apt-repository
+DEBIAN_FRONTEND=noninteractive apt-get install -y  python-software-properties
+
 # Enable multiverse repository
 add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) multiverse"
 apt-get update
@@ -89,7 +93,7 @@ python-gst0.10 python-flup gstreamer0.10-ffmpeg gstreamer0.10-fluendo-mp3 \
 gstreamer0.10-plugins-base gstreamer0.10-plugins-bad gstreamer0.10-plugins-good \
 gstreamer0.10-plugins-bad-multiverse gstreamer0.10-plugins-ugly libavcodec-extra-53 \
 python-pip gstreamer-tools python-setuptools python-profiler libmagic1 python-lxml \
-python-dev python-pycurl mediainfo
+python-dev mediainfo
 
 # Install/upgrade virtualenv
 pip install -U virtualenv

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -19,3 +19,4 @@ django-tastypie==0.9.16
 --allow-external django-ajax-filtered-fields
 --allow-unverified django-ajax-filtered-fields
 django-ajax-filtered-fields==0.5
+requests

--- a/roundware/settings/common.py
+++ b/roundware/settings/common.py
@@ -26,7 +26,7 @@ root = lambda * x: os.path.join(os.path.abspath(PROJECT_ROOT), *x)
 
 # TODO - Reduce number of audio/media file directories listed.
 # Roundwared & rwstreamd.py settings - Previously in /etc/roundware/rw
-ICECAST_PORT = 8000
+ICECAST_PORT = "8000"
 ICECAST_HOST = "localhost"
 ICECAST_USERNAME = "admin"
 ICECAST_PASSWORD = "roundice"

--- a/roundwared/db.py
+++ b/roundwared/db.py
@@ -275,9 +275,7 @@ def log_event(event_type, session_id, form):
 def add_asset_to_session_history_and_update_metadata(asset_id, session_id, duration):
     logger.debug("Called with recording " +
                  str(asset_id) + " session_id: " + str(session_id) + " duration: " + str(int(duration)))
-    admin = icecast2.Admin(settings.ICECAST_HOST + ":" + str(settings.ICECAST_PORT),
-                           settings.ICECAST_USERNAME,
-                           settings.ICECAST_PASSWORD)
+    admin = icecast2.Admin()
     admin.update_metadata(asset_id, session_id)
 
     s = Session.objects.get(id=session_id)

--- a/roundwared/server.py
+++ b/roundwared/server.py
@@ -883,24 +883,20 @@ def wait_for_stream(sessionid, audio_format):
     """
     Loops until the give stream is present and ready to be listened to.
     """
-    # Stream wait timeout in seconds
-    timeout = 30
-    # Number of retries timeout/(time to wait between retries)
-    retries_left = timeout / 0.2
+    # Number of retries
+    retries_left = 15
 
     logger.debug("Checking for existence of stream %s%s on %s:%s", sessionid,
                  audio_format, settings.ICECAST_HOST, settings.ICECAST_PORT)
     while not stream_exists(sessionid, audio_format):
-        time.sleep(0.2)
+        time.sleep(1)
         retries_left -= 1
         if retries_left < 0:
             raise roundexception.RoundException("Stream timeout on creation")
 
 
 def stream_exists(sessionid, audio_format):
-    admin = icecast2.Admin(settings.ICECAST_HOST + ":" + str(settings.ICECAST_PORT),
-                           settings.ICECAST_USERNAME,
-                           settings.ICECAST_PASSWORD)
+    admin = icecast2.Admin()
     return admin.stream_exists(icecast_mount_point(sessionid, audio_format))
 
 

--- a/roundwared/stream.py
+++ b/roundwared/stream.py
@@ -74,11 +74,7 @@ class RoundStream:
         self.last_listener_count = 1
         self.gps_mixer = None
         self.main_loop = gobject.MainLoop()
-        self.icecast_admin = icecast2.Admin(
-            settings.ICECAST_HOST + ":" +
-            str(settings.ICECAST_PORT),
-            settings.ICECAST_USERNAME,
-            settings.ICECAST_PASSWORD)
+        self.icecast_admin = icecast2.Admin()
         self.heartbeat()
         # project = models.Session.objects.get(id=sessionid)  # not used
         self.recordingCollection = \


### PR DESCRIPTION
I've also made the icecast2.Admin() constructor/init less complicated. No reason to pass the icecast admin values like that.

```
- self.icecast_admin = icecast2.Admin(
- settings.ICECAST_HOST + ":" +
- str(settings.ICECAST_PORT),
- settings.ICECAST_USERNAME,
- settings.ICECAST_PASSWORD)
+ self.icecast_admin = icecast2.Admin()
```
