### PR TITLE
Replace EXTERNAL_HOST_NAME_WITHOUT_PORT with request.get_host()

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ All Roundware specific settings are stored in roundware/settings/common.py
 
 Here are some simple browser tests to see if your Roundware installation is functioning properly (substitute your RW server url):
 
-    http://localhost:8888/api/1/rest/?operation=get_config&project_id=1
-    http://localhost:8888/api/1/rest/?operation=get_tags&session_id=1
-    http://localhost:8888/api/1/rest/?operation=request_stream&session_id=1
-    http://localhost:8888/api/1/rest/?operation=modify_stream&session_id=1
+    http://localhost:8888/api/1/?operation=get_config&project_id=1
+    http://localhost:8888/api/1/?operation=get_tags&session_id=1
+    http://localhost:8888/api/1/?operation=request_stream&session_id=1
+    http://localhost:8888/api/1/?operation=modify_stream&session_id=1
 
 The first two should return JSON objects containing information about your Roundware project. The second two will create and then modify an audio stream. You can verify stream creation in the Icecast admin, but of course, the true verification is by listening.
 

--- a/roundware/settings/common.py
+++ b/roundware/settings/common.py
@@ -36,9 +36,7 @@ ICECAST_PORT = "8000"
 ICECAST_HOST = "localhost"
 ICECAST_USERNAME = "admin"
 ICECAST_PASSWORD = "roundice"
-# TODO - Still used?
 ICECAST_SOURCE_USERNAME = "source"
-# TODO - Still used?
 ICECAST_SOURCE_PASSWORD = "roundice"
 # Default location for participant audio
 AUDIO_DIR = "/var/www/roundware/rwmedia"
@@ -54,7 +52,6 @@ MASTER_VOLUME = 3.0
 HEARTBEAT_TIMEOUT = 200
 # Radius in meters - default system wide setting
 RECORDING_RADIUS = 1
-EXTERNAL_HOST_NAME_WITHOUT_PORT = "example.com"
 DEMO_STREAM_CPU_LIMIT = 50.0
 # End Roundwared & rwstreamd.py settings
 
@@ -85,7 +82,6 @@ ALLOWED_MIME_TYPES = ALLOWED_AUDIO_MIME_TYPES + \
 # session_id assigned to files that are uploaded through the admin
 # MUST correspond to session_id that exists in session table
 DEFAULT_SESSION_ID = "-10"
-API_URL = "http://127.0.0.1/roundware/"
 MANAGERS = ADMINS
 # change this to the proper id for AnonymousUser in database for Guardian
 ANONYMOUS_USER_ID = -1

--- a/roundwared/server.py
+++ b/roundwared/server.py
@@ -688,7 +688,8 @@ def get_parameter_from_request(request, name, required):
 def request_stream(request):
 
     request_form = request.GET
-    hostname_without_port = settings.EXTERNAL_HOST_NAME_WITHOUT_PORT
+    # Get the value 'example.com' from the host 'example.com:8888'
+    http_host = request.get_host().split(':')[0]
 
     db.log_event(
         "request_stream", int(request_form['session_id']), request_form)
@@ -711,7 +712,7 @@ def request_stream(request):
         if project.demo_stream_url:
             url = project.demo_stream_url
         else:
-            url = "http://" + hostname_without_port + ":" + \
+            url = "http://" + http_host + ":" + \
                   str(settings.ICECAST_PORT) + \
                   "/demo_stream.mp3"
 
@@ -738,7 +739,7 @@ def request_stream(request):
             wait_for_stream(session.id, audio_format)
 
         return {
-            "stream_url": "http://" + hostname_without_port + ":" +
+            "stream_url": "http://" + http_host + ":" +
             str(settings.ICECAST_PORT) +
             icecast_mount_point(session.id, audio_format),
         }

--- a/roundwared/tests/common.py
+++ b/roundwared/tests/common.py
@@ -19,6 +19,9 @@ class FakeRequest(object):
     def __init__(self):
         self.GET = {}
 
+    def get_host(self):
+        return 'rw.com'
+
 
 def mock_distance_in_meters_near(l_lat, l_long, rec_lat, rec_long):
     return 1

--- a/roundwared/tests/test_server.py
+++ b/roundwared/tests/test_server.py
@@ -37,7 +37,6 @@ def mock_stream_exists(sessionid, audio_format):
 
 
 @patch.object(settings, 'ICECAST_PORT', 8000)
-@patch.object(settings, 'EXTERNAL_HOST_NAME_WITHOUT_PORT', 'rw.com')
 @patch.object(settings, 'ICECAST_HOST', 'rw.com')
 @patch.object(settings, 'AUDIO_FILE_URI', '/audio/')
 @patch.object(server, 'apache_safe_daemon_subprocess',


### PR DESCRIPTION
Replacing EXTERNAL_HOST_NAME_WITHOUT_PORT with request.get_host() simplifies request_stream results.

Localhost: http://localhost:8888/api/1/?operation=request_stream&project_id=1&session_id=1 responds with:

```
{
    "stream_url": "http://localhost:8000/stream1.mp3"
}
```

127.0.0.1: http://127.0.0.1:8888/api/1/?operation=request_stream&project_id=1&session_id=1 responds with:

```
{
    "stream_url": "http://127.0.0.1:8000/stream1.mp3"
}
```

Some other minor changes included, such as a README.md fix (oops) and removing API_URL from common.py too.
