### PR TITLE
Consolidate common.py media paths to fix #136

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ The base Roundware install package includes a standard DB fixture file to popula
 
 Make some edits to the Django settings file, `roundware/settings.py`:
 
-    AUDIO_FILE_URI = "http://example.com/audio/" //set to the proper path for your server
     ANONYMOUS_USER_ID = 0 // change this to the proper id for AnonymousUser in database for Guardian
     # settings for notifications module - email account from which notifications will be sent
     EMAIL_HOST = 'smtp.example.com'

--- a/docs/source/v1/installation/manual.html.md
+++ b/docs/source/v1/installation/manual.html.md
@@ -162,7 +162,6 @@ user@machine:~/roundware-server$ mysql
 Make some edits to the Django settings file, `roundware/settings.py`:
 
 ```
-AUDIO_FILE_URI = "http://roundware.org/audio/" //set to the proper path for your server
 ANONYMOUS_USER_ID = 0 // change this to the proper id for AnonymousUser in database for Guardian
 # settings for notifications module - email account from which notifications will be sent
 EMAIL_HOST = 'smtp.gmail.com'
@@ -208,44 +207,6 @@ export DJANGO_SETTINGS_MODULE=roundware.settings.dev
 
 Note also that you can use a `local_settings.py` (not in version control) inside
 of the `roundware/settings/` directory.
-
-## Roundware Config
-
-Roundware has a default config file as well as the option of having project-specific config files.  All Roundware config files are stored by default in `/etc/roundware/` and the default config is at `/etc/roundware/rw`
-
-```
-# network interface used
-interface = eth0
-# default port for icecast streams
-icecast_port = 8000
-# default location for participant audio (see asset table in db)
-audio_dir = /var/www/rwaudio
-# default location for incoming participant audio - may be used if incoming audio is ingested before included in piece
-upload_dir = /var/www/rwaudio
-# log file location
-log_file = /var/log/roundware
-# process id file
-pid_file = /var/run/roundware.pid
-# database auth
-dbuser = round
-dbpasswd = round
-dbname = roundware
-# settings
-num_pan_steps = 200     	# discrete steps
-stereo_pan_interval = 10      # milliseconds
-ping_interval = 10000   	# milliseconds
-master_volume = 3.0
-# determines connectivity to client.  When client stops beating, session is ended.  Time out in seconds.
-active_stream_check_scheme = heartbeat
-heartbeat_timeout = 200
-# recording radius in meters
-recording_radius = 10
-external_host_name_without_port = http://roundware.org
-```
-
-You need to edit the default config file to change `external_host_name_without_port` to the url of your RW server or else RW will return stream urls with the incorrect server.
-
-You should also go over the other parameters in the config just to make sure they correspond to your setup, such as the database info.
 
 ## Basic Testing
 

--- a/roundware/rw/admin.py
+++ b/roundware/rw/admin.py
@@ -121,19 +121,19 @@ class AssetAdmin(ProjectProtectedModelAdmin):
 
     def add_view(self, request, form_url='', extra_context=None):
         extra_context = extra_context or {}
-        extra_context['AUDIO_FILE_URI'] = getattr(settings, "AUDIO_FILE_URI")
+        extra_context['MEDIA_URL'] = settings.MEDIA_URL
         extra_context['extends_url'] = "admin/change_form.html"
         return super(AssetAdmin, self).add_view(request, form_url, extra_context=extra_context)
 
     def change_view(self, request, object_id, extra_context=None):
         extra_context = extra_context or {}
-        extra_context['AUDIO_FILE_URI'] = getattr(settings, "AUDIO_FILE_URI")
+        extra_context['MEDIA_URL'] = settings.MEDIA_URL
         extra_context['extends_url'] = "admin/change_form.html"
         return super(AssetAdmin, self).change_view(request, object_id, extra_context=extra_context)
 
     def changelist_view(self, request, extra_context=None):
         extra_context = extra_context or {}
-        extra_context['AUDIO_FILE_URI'] = getattr(settings, "AUDIO_FILE_URI")
+        extra_context['MEDIA_URL'] = settings.MEDIA_URL
         extra_context['extends_url'] = "admin/change_list.html"
         return super(AssetAdmin, self).changelist_view(request, extra_context=extra_context)
 

--- a/roundware/rw/models.py
+++ b/roundware/rw/models.py
@@ -27,17 +27,15 @@
 
 from __future__ import unicode_literals
 from django.core.cache import cache
-cache  # pyflakes, make sure it is imported, for patching in tests
+cache # pyflakes, make sure it is imported, for patching in tests
 from django.core.files.storage import FileSystemStorage
 from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.core.exceptions import NON_FIELD_ERRORS
 from django.db import models, transaction
-from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
-from roundware.settings import MEDIA_BASE_URI
+
 from roundware.rw import fields
 from django.conf import settings
-from datetime import datetime, date, timedelta
+from datetime import datetime
 from cache_utils.decorators import cached
 from roundwared.gpsmixer import distance_in_meters
 
@@ -356,9 +354,9 @@ class Asset(models.Model):
     longitude = models.FloatField(null=True, blank=False)
     filename = models.CharField(max_length=256, null=True, blank=True)
     file = fields.RWValidatedFileField(storage=FileSystemStorage(
-        location=getattr(settings, "MEDIA_BASE_DIR"),
-        base_url=getattr(settings, "MEDIA_BASE_URI"),),
-        content_types=getattr(settings, "ALLOWED_MIME_TYPES"),
+        location=settings.MEDIA_ROOT,
+        base_url=settings.MEDIA_URL,),
+        content_types=settings.ALLOWED_AUDIO_MIME_TYPES,
         upload_to=".", help_text="Upload file")
     volume = models.FloatField(null=True, blank=True, default=1.0)
 
@@ -435,7 +433,7 @@ class Asset(models.Model):
     audio_player.allow_tags = True
 
     def image_display(self):
-        image_src = "%s%s" % (MEDIA_BASE_URI, self.filename)
+        image_src = "%s%s" % (settings.MEDIA_URL, self.filename)
         return """<div data-filename="%s" class="media-display image-file"><a href="%s" target="imagepop"
                ><img src="%s" alt="%s" title="%s"/></a></div>""" % (
             self.filename, image_src, image_src,
@@ -479,7 +477,7 @@ class Asset(models.Model):
     norm_audiolength.allow_tags = True
 
     def media_link_url(self):
-        return '<a href="%s%s" target="_new">%s</a>' % (MEDIA_BASE_URI, self.filename, self.filename)
+        return '<a href="%s%s" target="_new">%s</a>' % (settings.MEDIA_URL, self.filename, self.filename)
     media_link_url.allow_tags = True
 
     def get_tags(self):

--- a/roundware/rw/templates/admin/asset_change_form.html
+++ b/roundware/rw/templates/admin/asset_change_form.html
@@ -2,7 +2,7 @@
 
 {% block extrahead %}
     <script type="text/javascript">
-        var AUDIO_FILE_SERVER = "{{ AUDIO_FILE_URI }}";
+        var AUDIO_FILE_SERVER = "{{ MEDIA_URL }}";
     </script>
     {{ block.super }}
 {% endblock %}

--- a/roundware/settings/common.py
+++ b/roundware/settings/common.py
@@ -30,7 +30,6 @@ ROUNDWARE_SERVER_ROOT = here("../..")
 # folder(s) we pass it starting at the roundware-server root
 root = lambda * x: os.path.join(os.path.abspath(PROJECT_ROOT), *x)
 
-# TODO - Reduce number of audio/media file directories listed.
 # Roundwared & rwstreamd.py settings - Previously in /etc/roundware/rw
 ICECAST_PORT = "8000"
 ICECAST_HOST = "localhost"
@@ -38,10 +37,6 @@ ICECAST_USERNAME = "admin"
 ICECAST_PASSWORD = "roundice"
 ICECAST_SOURCE_USERNAME = "source"
 ICECAST_SOURCE_PASSWORD = "roundice"
-# Default location for participant audio
-AUDIO_DIR = "/var/www/roundware/rwmedia"
-# Default location for incoming participant audio
-UPLOAD_DIR = "/var/www/roundware/rwmedia"
 # Discrete steps
 NUM_PAN_STEPS = 200
 # In milliseconds
@@ -53,26 +48,9 @@ HEARTBEAT_TIMEOUT = 200
 # Radius in meters - default system wide setting
 RECORDING_RADIUS = 1
 DEMO_STREAM_CPU_LIMIT = 50.0
-# End Roundwared & rwstreamd.py settings
-
-# url base for media files
-MEDIA_BASE_URI = "/rwmedia/"
-# external url where audio files can be accessed
-AUDIO_FILE_URI = MEDIA_BASE_URI  # + "audio"
-# external url where video files can be accessed
-VIDEO_FILE_URI = AUDIO_FILE_URI  # MEDIA_BASE_URI + "video"
-# external url where image files can be accessed
-IMAGE_FILE_URI = AUDIO_FILE_URI  # MEDIA_BASE_URI + "img"
-
-MEDIA_ROOT = ''
-MEDIA_BASE_DIR = "/var/www/roundware/rwmedia/"
-# internal path name to media file directories
-AUDIO_FILE_DIR = MEDIA_BASE_DIR  # + "audio"
-VIDEO_FILE_DIR = MEDIA_BASE_DIR  # + "video"
-IMAGE_FILE_DIR = MEDIA_BASE_DIR  # + "img"
 
 ALLOWED_AUDIO_MIME_TYPES = ['audio/x-wav', 'audio/wav',
-                            'audio/mpeg', 'audio/mp4a-latm', 'audio/x-caf',  'audio/mp3', ]
+                            'audio/mpeg', 'audio/mp4a-latm', 'audio/x-caf', 'audio/mp3', ]
 ALLOWED_IMAGE_MIME_TYPES = [
     'image/jpeg', 'image/gif', 'image/png', 'image/pjpeg', ]
 ALLOWED_TEXT_MIME_TYPES = ['text/plain', 'text/html', 'application/xml', ]
@@ -149,7 +127,7 @@ USE_L10N = True
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/home/media/media.lawrence.com/media/"
-MEDIA_ROOT = '/var/www/roundware/rwmedia'
+MEDIA_ROOT = '/var/www/roundware/rwmedia/'
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
@@ -201,7 +179,7 @@ TEMPLATE_LOADERS = (
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    #'django.middleware.csrf.CsrfViewMiddleware',
+    # 'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
 )
@@ -212,7 +190,7 @@ TEMPLATE_DIRS = (
     # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
-    #os.path.join(PROJECT_PATH, 'templates')
+    # os.path.join(PROJECT_PATH, 'templates')
     PROJECT_PATH + '/../templates',
     PROJECT_PATH + '/../rw/templates/rw',
 )

--- a/roundwared/composition.py
+++ b/roundwared/composition.py
@@ -57,7 +57,6 @@ class Composition:
 
     def __init__(self, parent, pipeline, adder, comp_settings, recordingColl):
         self.parent = parent
-        # logger.debug("---------Composition init")
         # logger.debug("---------Composition init: self.parent class: " + self.parent.__class__.__name__)
         # logger.debug("---------Composition init: self.parent.sessionid: " + str(self.parent.sessionid))
         self.pipeline = pipeline
@@ -158,7 +157,7 @@ class Composition:
                                 self.current_recording.filename, start, duration, fadein, fadeout, volume)
 
         self.roundfilesrc = roundfilesrc.RoundFileSrc(
-            "file://" + os.path.join(settings.AUDIO_DIR,
+            "file://" + os.path.join(settings.MEDIA_ROOT,
                                      self.current_recording.filename),
             start, duration, fadein, fadeout, volume)
         self.pipeline.add(self.roundfilesrc)

--- a/roundwared/convertaudio.py
+++ b/roundwared/convertaudio.py
@@ -36,7 +36,7 @@ from roundwared import roundexception
 # Handles files of various formats depending on the file extension.
 def convert_uploaded_file(filename):
     (filename_prefix, filename_extension) = os.path.splitext(filename)
-    upload_dir = get_upload_directory(filename_extension)
+    upload_dir = settings.MEDIA_ROOT
     filepath = os.path.join(upload_dir, filename)
     if not os.path.exists(filepath):
         raise roundexception.RoundException(
@@ -45,7 +45,7 @@ def convert_uploaded_file(filename):
         convert_audio_file(
             upload_dir, filename_prefix, filename_extension, 'wav')
         convert_audio_file(
-            settings.AUDIO_DIR, filename_prefix, '.wav', 'mp3')
+            settings.MEDIA_ROOT, filename_prefix, '.wav', 'mp3')
         return filename_prefix + '.wav'
     else:
         convert_audio_file(
@@ -59,19 +59,14 @@ def convert_uploaded_file(filename):
 def convert_audio_file(upload_dir, filename_prefix, filename_extension, dst_type):
     filepath = os.path.join(upload_dir, filename_prefix + filename_extension)
     if filename_extension == "." + dst_type:
-        if not settings.AUDIO_DIR == upload_dir:
+        if not settings.MEDIA_ROOT == upload_dir:
             shutil.copyfile(
                 filepath,
-                os.path.join(settings.AUDIO_DIR, filename_prefix + filename_extension))
+                os.path.join(settings.MEDIA_ROOT, filename_prefix + filename_extension))
     else:
         if filename_extension == '.caf':
             os.system("/usr/bin/pacpl --to " + dst_type + " --outdir " +
-                      settings.AUDIO_DIR + " " + filepath + ">/dev/null")
-        else:  # if filename_extension in ffmpeg supported list
-            os.system("/usr/bin/ffmpeg -y -i " + filepath + " " + os.path.join(settings.AUDIO_DIR,
+                      settings.MEDIA_ROOT + " " + filepath + ">/dev/null")
+        else: # if filename_extension in ffmpeg supported list
+            os.system("/usr/bin/ffmpeg -y -i " + filepath + " " + os.path.join(settings.MEDIA_ROOT,
                       filename_prefix + "." + dst_type) + " >/dev/null 2>/dev/null")
-
-
-# Gets the directory the file is uploaded to by which extension it has.
-def get_upload_directory(filename_extension):
-    return settings.UPLOAD_DIR

--- a/roundwared/discover_audiolength.py
+++ b/roundwared/discover_audiolength.py
@@ -33,7 +33,7 @@ from roundwared import roundexception
 
 
 def discover_and_set_audiolength(recording, filename):
-    filepath = os.path.join(settings.AUDIO_DIR, filename)
+    filepath = os.path.join(settings.MEDIA_ROOT, filename)
 
     cmd = ['mediainfo', '--Inform=General;%Duration%', filepath]
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/roundwared/recording_collection.py
+++ b/roundwared/recording_collection.py
@@ -125,7 +125,7 @@ class RecordingCollection:
 
         # If a recording was found and unit tests are not running.
         if recording and not settings.TESTING:
-            filepath = os.path.join(settings.AUDIO_DIR, recording.filename)
+            filepath = os.path.join(settings.MEDIA_ROOT, recording.filename)
             # Check if the file exists on the server.
             if not os.path.isfile(filepath):
                 recording = None

--- a/roundwared/server.py
+++ b/roundwared/server.py
@@ -463,7 +463,7 @@ def get_available_assets(request):
             assets_list.append(
                 dict(asset_id=asset.id,
                      asset_url='%s%s' % (
-                         settings.AUDIO_FILE_URI, asset.filename),
+                         settings.MEDIA_URL, asset.filename),
                      latitude=asset.latitude,
                      longitude=asset.longitude,
                      audio_length=asset.audiolength,
@@ -518,7 +518,7 @@ def create_envelope(request):
             "a session_id is required for this operation")
     s = models.Session.objects.get(id=form.get('session_id'))
 
-    #todo - tags
+    # todo - tags
 
     env = models.Envelope(session=s)
     env.save()
@@ -526,13 +526,13 @@ def create_envelope(request):
     return {"envelope_id": env.id}
 
 # add_asset_to_envelope (POST method)
-#args (operation, envelope_id, file, latitude, longitude, [tagids])
+# args (operation, envelope_id, file, latitude, longitude, [tagids])
 # example: http://localhost/roundware/?operation=add_asset_to_envelope
 # OR
 # add_asset_to_envelope (GET method)
 # args (operation, envelope_id, asset_id) #asset_id must point to an Asset that exists in the database
 # returns success bool
-#{"success": true}
+# {"success": true}
 # @profile(stats=True)
 
 
@@ -578,7 +578,7 @@ def add_asset_to_envelope(request):
         (filename_prefix, filename_extension) = \
             os.path.splitext(fileitem.name)
         fn = time.strftime("%Y%m%d-%H%M%S") + filename_extension
-        fileout = open(os.path.join(settings.AUDIO_DIR, fn), 'wb')
+        fileout = open(os.path.join(settings.MEDIA_ROOT, fn), 'wb')
         fileout.write(fileitem.file.read())
         fileout.close()
         # delete the uploaded original after the copy has been made
@@ -876,7 +876,7 @@ def apache_safe_daemon_subprocess(command):
         # stderr=subprocess.PIPE,
         env=env,
     )
-    #(stdout, stderr) = proc.communicate()
+    # (stdout, stderr) = proc.communicate()
     # logger.debug("subprocess_stdout: " + stdout)
     # logger.debug("subprocess_stdout: " + stderr)
 

--- a/roundwared/tests/test_server.py
+++ b/roundwared/tests/test_server.py
@@ -38,7 +38,7 @@ def mock_stream_exists(sessionid, audio_format):
 
 @patch.object(settings, 'ICECAST_PORT', 8000)
 @patch.object(settings, 'ICECAST_HOST', 'rw.com')
-@patch.object(settings, 'AUDIO_FILE_URI', '/audio/')
+@patch.object(settings, 'MEDIA_URL', '/audio/')
 @patch.object(server, 'apache_safe_daemon_subprocess',
               mock_apache_safe_daemon_subprocess)
 @patch.object(server, 'stream_exists', mock_stream_exists)


### PR DESCRIPTION
Getting rid of the extra media paths in common.py to make everything simpler. Unit tests pass, request_stream works. Minor code changes.
