### PR TITLE
Metadata - Add audiotrack ID, playlist length and asset complete.

### DIFF
--- a/roundwared/gpsmixer.py
+++ b/roundwared/gpsmixer.py
@@ -27,7 +27,7 @@ class GPSMixer (gst.Bin):
         ghostpad = gst.GhostPad("src", pad)
         self.add_pad(ghostpad)
         addersinkpad = self.adder.get_request_pad('sink%d')
-        logger.debug("Adding blank Audio")
+        logger.debug("Adding blank audio")
         blanksrc = BlankAudioSrc2()
         self.add(blanksrc)
         srcpad = blanksrc.get_pad('src')

--- a/roundwared/recording_collection.py
+++ b/roundwared/recording_collection.py
@@ -64,7 +64,7 @@ class RecordingCollection:
             self._update_nearby(request)
         logger.debug("Asset Counts - all: %s, playlist: %s, banned_proximity: %s, banned_timeout: %s." %
                      (len(self.all),
-                      len(self.playlist),
+                      self.count(),
                       len(self.banned_proximity),
                       len(self.banned_timeout),
                       ))
@@ -77,7 +77,7 @@ class RecordingCollection:
         self.lock.acquire()
         recording = None
         logger.debug("We have %s playlist recordings.",
-                     len(self.playlist))
+                     self.count())
 
         # If there are no playlist assets, but there are available played.
         if not self.has_nearby_unplayed() and self.has_played():
@@ -140,6 +140,9 @@ class RecordingCollection:
         Returns true if there are any recordings left to play.
         """
         return len(self.playlist) > 0
+
+    def count(self):
+        return len(self.playlist)
 
     def has_played(self):
         """

--- a/roundwared/stream.py
+++ b/roundwared/stream.py
@@ -9,6 +9,7 @@ pygst.require("0.10")
 import gst
 import logging
 import time
+import urllib
 from django.conf import settings
 from roundware.rw import models
 from roundware.api1.commands import log_event
@@ -62,7 +63,7 @@ class RoundStream:
         self.adder = gst.element_factory_make("adder")
         self.sink = RoundStreamSink(
             self.sessionid, self.audio_format, self.bitrate)
-        self.set_metadata("stream_started")
+        self.set_metadata({'stream_started': True})
         self.pipeline.add(self.adder, self.sink)
         self.adder.link(self.sink)
 
@@ -92,8 +93,8 @@ class RoundStream:
         self.activity_timestamp = time.time()
 
     # Sets the stream metadata using tag injection.
-    def set_metadata(self, data):
-        metadata = 'artist="Roundware",title="%s"' % data
+    def set_metadata(self, query):
+        metadata = 'artist="Roundware",title="%s"' % urllib.urlencode(query)
         self.sink.taginjector.set_property("tags", metadata)
 
     def modify_stream(self, request):


### PR DESCRIPTION
You mentioned the lack of an "asset complete" metadata update in #192. I wanted to implement that originally, but forgot. Having the image data stay up afterwards should be optional for the dev/user/etc. I've added everything I can think of to the metadata. Now it goes like this:
- stream_started=true
- audiotrack=1&remaining=0 (When nothing is in range)
- audiotrack=1&remaining=5&asset=2&tags=4%C23%C22 (When in range and a new asset is starting to play)
- audiotrack=1&remaining=5&asset=2&complete=true (When the current asset is complete)
- audiotrack=1&remaining=4&asset=4&tags=4%C23%C21
- audiotrack=1&remaining=4&asset=4&complete=true

Plus, this supports multiple audio tracks :)

Anything else it could show?
