### PR TITLE
Create and document outside-of-repo-code production Django/Roundware settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ROUNDWARE SERVER
 
-[![Build Status](https://travis-ci.org/hburgund/roundware-server.svg?branch=develop)](https://travis-ci.org/hburgund/roundware-server)
+[![Build Status](https://travis-ci.org/roundware/roundware-server.svg?branch=develop)](https://travis-ci.org/roundware/roundware-server)
 
 ## Overview
 
@@ -8,11 +8,11 @@ Roundware is a client-server system. The server runs using Apache HTTP Server an
 
 For more information about Roundware functionalities and projects that use the platform, please check out: [roundware.org](http://roundware.org "Roundware")
 
-## Basic Installation
+## Installation
 
 Roundware includes an *install.sh* to handle installation of the software and its dependencies. The majority of the process is automated. Further configuration is required for a production system, application specific details are below.
 
-    user@server:~ $ git clone https://github.com/hburgund/roundware-server.git
+    user@server:~ $ git clone https://github.com/roundware/roundware-server.git
     user@server:~ $ cd roundware-server
     user@server:~/roundware-server $ sudo ./install.sh
 
@@ -20,11 +20,20 @@ The installation process creates a *roundware* user as project owner. su to that
 
     sudo su - roundware
 
+## Production Settings
+
+The production Roundware/Django settings file used by WSGI Apache2 is stored
+outside of the source code directory in the file
+`/var/www/roundware/settings/roundware_production.py`. All
+settings in `/var/www/roundware/source/roundware/settings/common.py` can be
+overridden there. Do not modify any file within the `/var/www/roundware/source`
+directory unless you intend to maintain your own fork of Roundware Server.
+
 ## Vagrant
 
 A VagrantFile is included for local development and testing with [Vagrant](http://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org/). Usage:
 
-    user@local-machine:~ $ git clone https://github.com/hburgund/roundware-server.git
+    user@local-machine:~ $ git clone https://github.com/roundware/roundware-server.git
     user@local-machine:~ $ cd roundware-server
     user@local-machine:~/roundware-server $ vagrant up
     user@local-machine:~/roundware-server $ vagrant ssh
@@ -48,6 +57,8 @@ Notes:
 
     user@server:~/roundware-server $ git pull
     user@server:~/roundware-server $ sudo ./deploy.sh
+
+# Additional Details
 
 ## Icecast
 
@@ -152,10 +163,6 @@ environment variables) to add:
 
 Note: You can use a local_settings.py (not in version control) inside
 of the `roundware/settings/` directory.
-
-## Config
-
-All Roundware specific settings are stored in `roundware/settings/common.py`
 
 ## Testing
 

--- a/files/roundware.wsgi
+++ b/files/roundware.wsgi
@@ -5,6 +5,7 @@ import site
 SITE_PACKAGES = '/var/www/roundware/lib/python2.7/site-packages/'
 PROJECT_ROOT = '/var/www/roundware/source/'
 CODE_ROOT = '/var/www/roundware/source/roundware/'
+SETTINGS_ROOT = '/var/www/roundware/settings/'
 ACTIVATE_VENV = '/var/www/roundware/bin/activate_this.py'
 
 sys.stdout = sys.stderr
@@ -12,7 +13,8 @@ sys.stdout = sys.stderr
 site.addsitedir(SITE_PACKAGES)
 sys.path.append(PROJECT_ROOT)
 sys.path.append(CODE_ROOT)
-os.environ['DJANGO_SETTINGS_MODULE'] = 'roundware.settings'
+sys.path.append(SETTINGS_ROOT)
+os.environ['DJANGO_SETTINGS_MODULE'] = 'roundware_production'
 
 # Enable Virtual Environment
 execfile(ACTIVATE_VENV, dict(__file__=ACTIVATE_VENV))

--- a/files/var-www-roundware-settings.py
+++ b/files/var-www-roundware-settings.py
@@ -1,0 +1,28 @@
+"""
+Roundware Server Production Settings
+
+This file will be copied to /var/www/roundware/settings/roundware-production.py during
+the Roundware Server installation.
+
+It is used as the Django DJANGO_SETTINGS_MODULE in the WSGI file for Apache to
+allow server customization of the stock settings.
+"""
+from roundware.settings import *
+
+# Admin account(s) to receive error log messages.
+ADMINS = (
+    ('round', 'username@example.com'),
+)
+
+# The SMTP email account used for outgoing mail.
+EMAIL_HOST = 'smtp.example.com'
+EMAIL_HOST_USER = 'username@example.com'
+EMAIL_HOST_PASSWORD = 'password'
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+
+# Standard Django DEBUG setting
+DEBUG = False
+# The roundware log file /var/log/roundware detail level.
+# INFO is default. Set to DEBUG for detailed information.
+LOGGING['handlers']['file']['level'] = 'INFO'

--- a/install.sh
+++ b/install.sh
@@ -98,11 +98,8 @@ mkdir -p $STATIC_PATH
 # copy test audio file to media storage
 cp $SOURCE_PATH/files/rw_test_audio1.wav $MEDIA_PATH
 
-# Setup apache
-a2enmod rewrite
-a2enmod wsgi
-a2enmod headers
-a2dissite 000-default
+# Copy default production settings file
+cp $SOURCE_PATH/files/var-www-roundware-settings.py $WWW_PATH/settings/roundware_production.py
 
 # Setup roundware log and logrotate
 touch /var/log/roundware
@@ -111,6 +108,11 @@ chown $USERNAME:$USERNAME /var/log/roundware
 # Run the production upgrade/deployment script
 $SOURCE_PATH/deploy.sh
 
+# Setup Apache Server
+a2enmod rewrite
+a2enmod wsgi
+a2enmod headers
+a2dissite 000-default
 # Setup roundware in Apache
 rm -f /etc/apache2/sites-available/roundware.conf
 sed s/USERNAME/$USERNAME/g $CODE_PATH/files/etc-apache2-sites-available-roundware > /etc/apache2/sites-available/roundware.conf
@@ -118,7 +120,8 @@ a2ensite roundware
 
 # Setup logrotate
 sed s/USERNAME/$USERNAME/g $CODE_PATH/files/etc-logrotate-d-roundware > /etc/logrotate.d/roundware
-# install correct shout2send gstreamer plugin
+
+# Install correct shout2send gstreamer plugin
 mv /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstshout2.so /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstshout2.so.old
 cp $CODE_PATH/files/64-bit/libgstshout2.so /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstshout2.so
 

--- a/roundware/settings/common.py
+++ b/roundware/settings/common.py
@@ -51,7 +51,8 @@ RECORDING_RADIUS = 1
 DEMO_STREAM_CPU_LIMIT = 50.0
 
 ALLOWED_AUDIO_MIME_TYPES = ['audio/x-wav', 'audio/wav',
-                            'audio/mpeg', 'audio/mp4a-latm', 'audio/x-caf', 'audio/mp3', ]
+                            'audio/mpeg', 'audio/mp4a-latm', 'audio/x-caf',
+                            'audio/mp3', 'video/quicktime']
 ALLOWED_IMAGE_MIME_TYPES = [
     'image/jpeg', 'image/gif', 'image/png', 'image/pjpeg', ]
 ALLOWED_TEXT_MIME_TYPES = ['text/plain', 'text/html', 'application/xml', ]
@@ -64,8 +65,8 @@ DEFAULT_SESSION_ID = "-10"
 MANAGERS = ADMINS
 # change this to the proper id for AnonymousUser in database for Guardian
 ANONYMOUS_USER_ID = -1
-# settings for notifications module
-# this is the email account from which notifications will be sent
+
+# The email account from which notifications will be sent
 EMAIL_HOST = 'smtp.example.com'
 EMAIL_HOST_USER = 'email@example.com'
 EMAIL_HOST_PASSWORD = 'password'
@@ -268,12 +269,12 @@ LOGGING = {
         },
         # The roundware system logger.
         'roundware': {
-            'level': 'INFO',
+            'level': 'DEBUG',
             'handlers': ['file', 'mail_admins'],
         },
         # The roundwared stream manager logger.
         'roundwared': {
-            'level': 'INFO',
+            'level': 'DEBUG',
             'handlers': ['file', 'mail_admins'],
         },
     },


### PR DESCRIPTION
Could use a better explanation but this covers it:


## Production Settings

The production Roundware/Django settings file used by WSGI Apache2 is stored outside of the source code directory in the file `/var/www/roundware/settings/roundware_production.py`. All settings in `/var/www/roundware/source/roundware/settings/common.py` can be overridden there. Do not modify any file within the `/var/www/roundware/source` directory unless you intend to maintain your own fork of Roundware Server.
