### PR TITLE
Symlink ~/roundware-server to Apache code on production servers so manage.py works

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -49,11 +49,10 @@ if [ ! "$FOUND_VAGRANT" = true ]; then
     useradd $USERNAME -s /bin/bash -m -d $HOME_PATH
   fi
 
-  # If source and dev code paths are different, copy source to code.
+  # If source and dev code paths are different, create a symbolic link to code.
   if [ $SOURCE_PATH != $DEV_CODE_PATH ]; then
     rm -rf $DEV_CODE_PATH
-    mkdir -p $DEV_CODE_PATH
-    cp -R $SOURCE_PATH/. $DEV_CODE_PATH
+    ln -sfn $CODE_PATH $DEV_CODE_PATH
   fi
 fi
 


### PR DESCRIPTION
@hburgund and I discovered an issue with the production server upgrade process. We couldn't get Django migrations to run while using the `roundware` user (Note: `vagrant` user is used on development VMs.) The issue was `install.sh` was making another copy of the codebase for the `roundware` user, but `deploy.sh` was never updating it. The solution is for `~/roundware-server` to always be symbolic link. On dev VMs it goes to `/vagrant` and on production systems it goes to `/var/www/roundware/source/`. The `roundware` or `vagrant` user `.profile` [always deferences the symbolic link](https://github.com/roundware/roundware-server/blob/ed156f1b626db8e89d721cbb57cb8dc01862c478/files/home-user-profile#L29) to create the PYTHON_PATH environment variable.

Now the following will work on a production machine (so it acts the same as on dev):
```bash
sudo su - roundware
cd ~/roundware-server/roundware
./manage.py migrate
```

This commit fixes the issue for new installations. The following will "upgrade" existing production installs:
```bash
sudo rm -rf /home/roundware/roundware-server/
sudo ln -snf /var/www/roundware/source/ /home/roundware/roundware-server
```