### PR TITLE
#214 - allow authorization header to pass through WSGI

### DIFF
--- a/files/etc-apache2-sites-available-roundware
+++ b/files/etc-apache2-sites-available-roundware
@@ -37,6 +37,7 @@
   WSGIApplicationGroup %{GLOBAL}
   WSGIProcessGroup roundware
   WSGIScriptAlias / /var/www/roundware/source/files/roundware.wsgi
+  WSGIPassAuthorization On
 
   # allow CORS for listen map, session map etc
   Header set Access-Control-Allow-Origin "*"


### PR DESCRIPTION
Changes the Apache VirtualHost container to allow the Authorization header to be received by Django Rest Framework.  This is needed for the implementation of token authorization.