### PR TITLE
adding timed asset inline to the asset admin view...

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 Roundware Server v0.3, XXXX-XX-XX (development version)
 ---------------------
+- Adding Timed Asset inline on the Asset Admin view to simplify Timed Asset creation.
 - Added UPGRADING.md and CHANGELOG.txt
 - Fixed recording_collection._banned asset status function.
 - Created Timed Playlist to manage audiotrack audio instead of relying on move_listener calls.

--- a/roundware/rw/admin.py
+++ b/roundware/rw/admin.py
@@ -24,6 +24,11 @@ class EnvelopeInline(admin.StackedInline):
     verbose_name_plural = "Related Envelope"
 
 
+class TimedAssetInline(admin.TabularInline):
+    model = TimedAsset
+    extra = 1
+
+
 class AssetTagsInline(admin.TabularInline):
     model = Asset.tags.through
 
@@ -157,6 +162,7 @@ class AssetAdmin(ProjectProtectedModelAdmin):
     inlines = [
         EnvelopeInline,
         VoteInline,
+        TimedAssetInline,
     ]
     #exclude = ('tags',)
     # , 'longitude', 'latitude')#, 'filename')


### PR DESCRIPTION
... to allow for more intuitive ability to add timed assets; you can now add timed assets from the asset itself rather than only from the timed asset admin screen which requires knowledge of specific asset ids.  This is a partial fix to #225.
