### PR TITLE
adding project.timed_asset_priority to allow for easy config of timed assets taking priority or not over geo-assets.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,8 @@
 Roundware Server v0.3, XXXX-XX-XX (development version)
 ---------------------
+- Added project-level option for prioritization of timed-assets.
 - Fixed project continuous mode; previously it would never take effect.
-- Fixed global listen (when geolisten is disabled) and added unit tests. 
+- Fixed global listen (when geolisten is disabled) and added unit tests.
 - Adding Timed Asset inline on the Asset Admin view to simplify Timed Asset creation.
 - Change default tag filter from "--" to empty string to fix stream tag filtering.
 - Add "Browse" UI Mode for manual browsing of content

--- a/roundware/rw/admin.py
+++ b/roundware/rw/admin.py
@@ -279,8 +279,8 @@ class ProjectAdmin(GuardedModelAdmin):
         }),
         ('Configuration', {
             'fields': ('listen_enabled', 'geo_listen_enabled', 'speak_enabled', 'geo_speak_enabled',
-                       'demo_stream_enabled', 'reset_tag_defaults_on_startup', 'max_recording_length',
-                       'recording_radius', 'audio_stream_bitrate', 'sharing_url',
+                       'demo_stream_enabled', 'reset_tag_defaults_on_startup', 'timed_asset_priority',
+                       'max_recording_length', 'recording_radius', 'audio_stream_bitrate', 'sharing_url',
                        'out_of_range_url', 'demo_stream_url', 'files_url', 'files_version', 'repeat_mode', 'ordering')
         }),
         ('Localized Strings', {

--- a/roundware/rw/migrations/0008_project_timed_asset_priority.py
+++ b/roundware/rw/migrations/0008_project_timed_asset_priority.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rw', '0007_repeat_mode'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='timed_asset_priority',
+            field=models.BooleanField(default=True),
+            preserve_default=True,
+        ),
+    ]

--- a/roundware/rw/models.py
+++ b/roundware/rw/models.py
@@ -73,6 +73,7 @@ class Project(models.Model):
     speak_enabled = models.BooleanField(default=False)
     geo_speak_enabled = models.BooleanField(default=False)
     reset_tag_defaults_on_startup = models.BooleanField(default=False)
+    timed_asset_priority = models.BooleanField(default=True)
     legal_agreement_loc = models.ManyToManyField(
         LocalizedString, related_name='legal_agreement_string', null=True, blank=True)
     repeat_mode = models.CharField(default=STOP, max_length=10, blank=False,

--- a/roundwared/recording_collection.py
+++ b/roundwared/recording_collection.py
@@ -123,10 +123,11 @@ class RecordingCollection:
         Returns an item from the timed playlist if any exist, return a
         an item from the proximity playlist if any exist, otherwise return None
         """
-        self._update_playlist_timed()
-
-        if len(self.playlist_timed) > 0:
-            return self.playlist_timed.pop()
+        # prioritize timed-assets before proximity assets
+        if self.project.timed_asset_priority:
+            self._update_playlist_timed()
+            if len(self.playlist_timed) > 0:
+                return self.playlist_timed.pop()
 
         # If there are no playlist_proximity assets available, but there are
         # played assets available.
@@ -144,6 +145,12 @@ class RecordingCollection:
         # If there are now any recordings available, get one.
         if len(self.playlist_proximity) > 0:
             return self.playlist_proximity.pop()
+
+        # prioritize timed-assets after proximity assets
+        if not self.project.timed_asset_priority:
+            self._update_playlist_timed()
+            if len(self.playlist_timed) > 0:
+                return self.playlist_timed.pop()
 
         return None
 

--- a/tests/roundwared/test_recording_collection.py
+++ b/tests/roundwared/test_recording_collection.py
@@ -4,7 +4,7 @@ from mock import patch
 
 from .common import (RoundwaredTestCase, mock_distance_in_meters_near)
 from roundware.rw.models import (Session, Asset,
-                                 Project, MasterUI, UIMapping, Tag)
+                                 Project, MasterUI, UIMapping, Tag, TimedAsset)
 from roundwared.recording_collection import RecordingCollection
 from roundwared.stream import RoundStream
 from roundwared import gpsmixer
@@ -29,9 +29,16 @@ class TestRecordingCollection(RoundwaredTestCase):
         self.project2 = mommy.make(Project, name='Project Two',
                                    recording_radius=20,
                                    geo_listen_enabled=True)
+        self.project3 = mommy.make(Project, name='Project Three',
+                                   recording_radius=10,
+                                   repeat_mode=Project.STOP,
+                                   geo_listen_enabled=True,
+                                   timed_asset_priority=True)
         self.session1 = mommy.make(Session, project=self.project1,
                                    language=self.english)
         self.session2 = mommy.make(Session, project=self.project2,
+                                   language=self.english)
+        self.session3 = mommy.make(Session, project=self.project3,
                                    language=self.english)
         # A new tag only for asset #3.
         self.tag2 = mommy.make(Tag, data="{'json':'value'}",
@@ -45,6 +52,10 @@ class TestRecordingCollection(RoundwaredTestCase):
         self.req2 = {"session_id": self.session1.id,
                      "project_id": self.project1.id,
                      "audio_stream_bitrate": '128'}
+        self.req3 = {"session_id": self.session3.id,
+                     "project_id": self.project3.id,
+                     "audio_stream_bitrate": '128',
+                     "latitude": 0.1, "longitude": 0.1}
         self.asset1 = mommy.make(Asset, project=self.project1,
                                  language=self.english,
                                  tags=[self.tag1],
@@ -60,16 +71,33 @@ class TestRecordingCollection(RoundwaredTestCase):
                                  tags=[self.tag2],
                                  audiolength=2000, weight=200,
                                  latitude=0.1, longitude=0.1)
+        self.asset4 = mommy.make(Asset, project=self.project3,
+                                 language=self.english,
+                                 tags=[self.tag2],
+                                 audiolength=2000, weight=50,
+                                 latitude=2, longitude=2)
+        self.asset5 = mommy.make(Asset, project=self.project3,
+                                 language=self.english,
+                                 tags=[self.tag2],
+                                 audiolength=2000, weight=200,
+                                 latitude=0.1, longitude=0.1)
         self.masterui1 = mommy.make(MasterUI, project=self.project1,
                                     ui_mode=MasterUI.LISTEN,
                                     tag_category=self.tagcat1)
         self.masterui2 = mommy.make(MasterUI, project=self.project1,
                                     ui_mode=MasterUI.LISTEN,
                                     tag_category=self.tagcat1)
+        self.masterui3 = mommy.make(MasterUI, project=self.project3,
+                                    ui_mode=MasterUI.LISTEN,
+                                    tag_category=self.tagcat1)
         self.uimapping1 = mommy.make(UIMapping, master_ui=self.masterui1,
                                      tag=self.tag1, default=True, active=True)
         self.uimapping2 = mommy.make(UIMapping, master_ui=self.masterui1,
                                      tag=self.tag2, default=True, active=True)
+        self.uimapping3 = mommy.make(UIMapping, master_ui=self.masterui3,
+                                     tag=self.tag2, default=True, active=True)
+        self.timedasset1 = mommy.make(TimedAsset, project=self.project3,
+                                     asset=self.asset4, start=0, end=15)
 
     def test_instantiate_recording_collection(self):
         req = self.req1
@@ -272,4 +300,34 @@ class TestRecordingCollection(RoundwaredTestCase):
         rc = RecordingCollection(stream, req, stream.radius, 'by_weight')
 
         self.assertEquals(None, rc.get_recording())
+
+    def test_timed_asset_priority_true(self):
+        """ Test that _get_recording returns a proximity asset instead of a
+            timed asset when project.timed_asset_priority=True.
+        """
+
+        stream = RoundStream(self.session3.id, 'ogg', self.req3)
+        rc = RecordingCollection(stream, self.req3, stream.radius, 'by_weight')
+        # Force/Fake start the RC timer; needed for timed asset selection
+        rc.start()
+        # Update the list of nearby recordings
+        rc.update_request(self.req3)
+        self.assertEquals(self.asset4, rc.get_recording())
+        self.assertEquals(self.asset5, rc.get_recording())
+
+    def test_timed_asset_priority_false(self):
+        """ Test that _get_recording returns a proximity asset instead of a
+            timed asset when project.timed_asset_priority=False.
+        """
+        self.project3.timed_asset_priority = False
+        self.project3.save()
+        stream = RoundStream(self.session3.id, 'ogg', self.req3)
+
+        rc = RecordingCollection(stream, self.req3, stream.radius, 'by_weight')
+        # Force/Fake start the RC timer; needed for timed asset selection
+        rc.start()
+        # Update the list of nearby recordings
+        rc.update_request(self.req3)
+        self.assertEquals(self.asset5, rc.get_recording())
+        self.assertEquals(self.asset4, rc.get_recording())
 


### PR DESCRIPTION
This is a preliminary pull request to get feedback.
- I attempted to adjust the migration details to take into account the migration in current pull request #239, so that one must be merged first.
- It seems to me that I could have been more elegant with the if statements in `recording_collection` as there is repeated code, so suggestions welcome.
- Also, there are no unit tests; as I am new to those, advice on what should be tested and approach would be great so I can work on that.
