### PR TITLE
Make github recognize as a Python project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+docs/source/docjs/* linguist-vendored
+roundware/rw/static/dashboard/js/* linguist-vendored
+


### PR DESCRIPTION
_I know this is minor and not really important, but I was wondering about it and found the solution_

This project is currently reported as a Javascript project. If this is merged and #264 fixed. It will be recognized as a Python project.

![rwpython](https://cloud.githubusercontent.com/assets/195061/11837230/622bbce6-a394-11e5-946a-3c2636b5a8b0.png)

Github Linguist details: https://github.com/github/linguist#troubleshooting
