### PR TITLE
Audio stream manipulation fixes and additions

### DIFF
--- a/roundware/api1/commands.py
+++ b/roundware/api1/commands.py
@@ -17,7 +17,7 @@ from roundware.lib import dbus_send
 from roundware.lib.exception import RoundException
 from roundwared import gpsmixer
 from roundware.lib.api import (get_project_tags_old as get_project_tags, t, log_event, form_to_request,
-                               check_for_single_audiotrack, get_parameter_from_request)
+                               check_for_single_audiotrack, get_parameter_from_request, play)
 
 logger = logging.getLogger(__name__)
 
@@ -41,23 +41,9 @@ def get_asset_info(request):
 
 
 def play_asset_in_stream(request):
-    form = request.GET
 
-    request = form_to_request(form)
-    arg_hack = json.dumps(request)
-    log_event("play_asset_in_stream", int(form['session_id']), form)
-
-    if 'session_id' not in form:
-        raise RoundException("a session_id is required for this operation")
-    if not check_for_single_audiotrack(form.get('session_id')):
-        raise RoundException(
-            "this operation is only valid for projects with 1 audiotrack")
-    if 'asset_id' not in form:
-        raise RoundException(
-            "an asset_id is required for this operation")
-    dbus_send.emit_stream_signal(
-        int(form['session_id']), "play_asset", arg_hack)
-    return {"success": True}
+    # APIv2 uses POST, APIv1 uses GET for this command
+    return play( request.GET )
 
 
 # @profile(stats=True)

--- a/roundware/api1/urls.py
+++ b/roundware/api1/urls.py
@@ -3,14 +3,14 @@
 
 
 from __future__ import unicode_literals
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from roundware.api1 import views
 import logging
 logger = logging.getLogger(__name__)
 
-urlpatterns = patterns('',
+urlpatterns = [
     # V1 API
-    url(r'^$', 'api1.views.operations'),
+    url(r'^$', views.operations),
     url(r'^auth/', include('rest_framework.urls',
                                namespace='rest_framework')),
 
@@ -32,4 +32,4 @@ urlpatterns = patterns('',
     url(r'^rest/listeninghistoryitem/$',
         views.ListeningHistoryItemList.as_view(),
         name='api1-listeninghistoryitem'),
-)
+]

--- a/roundware/api1/views.py
+++ b/roundware/api1/views.py
@@ -86,7 +86,7 @@ def operation_to_function(operation):
         "get_tags": commands.get_tags_for_project,
         "modify_stream": api.modify_stream,
         "move_listener": api.move_listener,
-        "get_current_streaming_asset": api.get_current_streaming_asset,
+        "get_current_streaming_asset": api.get_currently_streaming_asset,
         "get_asset_info": commands.get_asset_info,
         "get_available_assets": commands.get_available_assets,
         "play_asset_in_stream": commands.play_asset_in_stream,

--- a/roundware/api2/urls.py
+++ b/roundware/api2/urls.py
@@ -3,7 +3,7 @@
 
 
 from __future__ import unicode_literals
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from rest_framework.routers import DefaultRouter
 from roundware.api2 import views
 import logging
@@ -26,6 +26,6 @@ router.register(r'uigroups', views.UIGroupViewSet)
 router.register(r'uiitems', views.UIItemViewSet)
 
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^', include(router.urls)),
-)
+]

--- a/roundware/lib/api.py
+++ b/roundware/lib/api.py
@@ -387,6 +387,54 @@ def skip_ahead(request, session_id=None):
     return {"success": True}
 
 
+def play(form):
+    session_id = int(form['session_id'])
+    request = form_to_request(form)
+    arg_hack = json.dumps(request)
+
+    log_event("play_asset_in_stream", session_id, form)
+
+    if 'session_id' not in form:
+        raise RoundException("a session_id is required for this operation")
+    if not check_for_single_audiotrack(form.get('session_id')):
+        raise RoundException("this operation is only valid for projects with 1 audiotrack")
+    if 'asset_id' not in form:
+        raise RoundException("an asset_id is required for this operation")
+
+    # Check if asset exists
+    if not models.Asset.objects.filter(id=form['asset_id']).exists():
+        raise RoundException("no asset found with this asset_id")
+
+    dbus_send.emit_stream_signal(session_id, "play_asset", arg_hack)
+
+    return {"success": True}
+
+
+def pause(request, session_id=None):
+    if session_id is None:
+        session_id = request.GET.get('session_id', None)
+    if session_id is None:
+        raise RoundException("a session_id is required for this operation")
+
+    logger.debug("pausing")
+    log_event("pause", int(session_id))
+
+    dbus_send.emit_stream_signal(int(session_id), "pause", "")
+    return {"success": True}
+
+
+def resume(request, session_id=None):
+    if session_id is None:
+        session_id = request.GET.get('session_id', None)
+    if session_id is None:
+        raise RoundException("a session_id is required for this operation")
+
+    logger.debug("resuming")
+    log_event("resume", int(session_id))
+
+    dbus_send.emit_stream_signal(int(session_id), "resume", "")
+    return {"success": True}
+
 def check_for_single_audiotrack(session_id):
     ret = False
     session = models.Session.objects.select_related(
@@ -603,7 +651,7 @@ def get_parameter_from_request(request, name, required=False):
     return ret
 
 
-def get_current_streaming_asset(request, session_id=None):
+def get_currently_streaming_asset(request, session_id=None):
     if session_id is None:
         session_id = request.GET.get('session_id', None)
     if session_id is None:

--- a/roundware/rw/urls.py
+++ b/roundware/rw/urls.py
@@ -2,12 +2,11 @@
 # See COPYRIGHT.txt, AUTHORS.txt, and LICENSE.txt in the project root directory.
 
 from __future__ import unicode_literals
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from roundware.rw import views
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^tags/batch_add$', views.MultiCreateTagsView.as_view()),
     # url(r'^uigroups/(?P<pk>\d+)/setup_tag_ui/$',
     #    views.SetupTagUIView.as_view()),
@@ -17,4 +16,4 @@ urlpatterns = patterns(
         views.UIGroupMappingsOrganizationView.as_view()),
     url(r'^uigroups/setup_tag_ui/update_tag_ui_order',
         views.UpdateTagUIOrder.as_view()),
-)
+]

--- a/roundware/settings/common.py
+++ b/roundware/settings/common.py
@@ -4,11 +4,10 @@ import os
 # More details here: https://github.com/tomchristie/django-rest-framework/issues/1338
 from dateutil import parser
 from django.forms import fields
+
 fields.DateTimeField.strptime = lambda o, v, f: parser.parse(v)
 
-
 DEBUG = False
-TEMPLATE_DEBUG = False
 # True when unit tests are running. Used by roundwared.recording_collection
 TESTING = False
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
@@ -19,18 +18,19 @@ ADMINS = (
 
 # here() gives us file paths from the root of the system to the directory
 # holding the current file.
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__))) # 1.8
-here = lambda * x: os.path.join(os.path.abspath(os.path.dirname(__file__)), *x)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # 1.8
+here = lambda *x: os.path.join(os.path.abspath(os.path.dirname(__file__)), *x)
 
 # Root of roundware Django project
 PROJECT_ROOT = here("../..")
+PROJECT_PATH = os.path.abspath(os.path.dirname(__file__))
 
 # Root of roundware-server
 ROUNDWARE_SERVER_ROOT = here("../..")
 
 # root() gives us file paths from the root of the system to whatever
 # folder(s) we pass it starting at the roundware-server root
-root = lambda * x: os.path.join(os.path.abspath(PROJECT_ROOT), *x)
+root = lambda *x: os.path.join(os.path.abspath(PROJECT_ROOT), *x)
 
 # Roundwared & rwstreamd.py settings
 ICECAST_PORT = "8000"
@@ -58,7 +58,7 @@ ALLOWED_IMAGE_MIME_TYPES = ['image/jpeg', 'image/gif', 'image/png', 'image/pjpeg
 ALLOWED_TEXT_MIME_TYPES = ['text/plain', 'text/html', 'application/xml']
 ALLOWED_VIDEO_MIME_TYPES = ['video/quicktime']
 ALLOWED_MIME_TYPES = ALLOWED_AUDIO_MIME_TYPES + ALLOWED_IMAGE_MIME_TYPES \
-    + ALLOWED_TEXT_MIME_TYPES + ALLOWED_VIDEO_MIME_TYPES
+                     + ALLOWED_TEXT_MIME_TYPES + ALLOWED_VIDEO_MIME_TYPES
 
 # session_id assigned to files that are uploaded through the admin
 # MUST correspond to session_id that exists in session table
@@ -82,7 +82,6 @@ BANNED_TIMEOUT_LIMIT = 1800
 # change this to reflect your environment
 # JSS: this will always set PROJECT_PATH to the directory in which
 # settings.py is contained
-PROJECT_PATH = os.path.abspath(os.path.dirname(__file__))
 DATABASES = {
     'default': {
         # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or
@@ -125,7 +124,7 @@ USE_I18N = True
 # calendars according to the current locale
 USE_L10N = True
 
-USE_TZ = False # Django 1.9 (timezone)
+USE_TZ = False  # Django 1.9 (timezone)
 
 # Absolute filesystem path to the directory that will hold user-uploaded files.
 # Example: "/home/media/media.lawrence.com/media/"
@@ -173,11 +172,31 @@ STATICFILES_FINDERS = (
 SECRET_KEY = '2am)ks1i88hss27e7uri%$#v4717ms6p869)2%cc*w7oe61q6^'
 
 # List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-    #     'django.template.loaders.eggs.Loader',
-)
+TEMPLATES = [
+    {
+        "BACKEND": 'django.template.backends.django.DjangoTemplates',
+        "DIRS": [
+            PROJECT_PATH + '/../templates',
+            PROJECT_PATH + '/../rw/templates/rw'
+        ],
+        "OPTIONS": {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+            "debug": DEBUG,
+            "loaders": [
+                'django.template.loaders.filesystem.Loader',
+                'django.template.loaders.app_directories.Loader'
+            ]
+        }
+    }
+]
 
 MIDDLEWARE_CLASSES = (
     'corsheaders.middleware.CorsMiddleware',
@@ -192,27 +211,18 @@ ROOT_URLCONF = 'roundware.urls'
 
 WSGI_APPLICATION = 'roundware.wsgi.application'
 
-TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    # os.path.join(PROJECT_PATH, 'templates')
-    PROJECT_PATH + '/../templates',
-    PROJECT_PATH + '/../rw/templates/rw',
-)
-
 # The numbers in comments indicate rough loading order for troubleshooting
 INSTALLED_APPS = (
-    'django.contrib.auth', #1
-    'django.contrib.contenttypes', #2
+    'django.contrib.auth',  # 1
+    'django.contrib.contenttypes',  # 2
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.gis',
     'django_admin_bootstrapped',
-    'django.contrib.admin.apps.SimpleAdminConfig', #5
-    'guardian', #3
+    'django.contrib.admin.apps.SimpleAdminConfig',  # 5
+    'guardian',  # 3
     'chartit',
     'validatedfile',
     'adminplus',
@@ -226,7 +236,7 @@ INSTALLED_APPS = (
     'leaflet',
     'corsheaders',
     'roundware.lib',
-    'roundware.rw', #4
+    'roundware.rw',  # 4
     'roundware.notifications',
     'roundware.api1',
     'roundware.api2',
@@ -246,15 +256,14 @@ REST_FRAMEWORK = {
         'rest_framework.throttling.UserRateThrottle'
     ),
     'DEFAULT_THROTTLE_RATES': {
-        'anon': '100000/day', # previously 100
-        'user': '1000000/day' # previously 1000
+        'anon': '100000/day',  # previously 100
+        'user': '1000000/day'  # previously 1000
     }
 }
 
 CORS_ORIGIN_WHITELIST = (
     'localhost:8080',
 )
-
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to

--- a/roundware/settings/dev.py
+++ b/roundware/settings/dev.py
@@ -12,12 +12,14 @@ BANNED_TIMEOUT_LIMIT = 90
 # Remove possibility of demo stream to avoid confusion while testing
 DEMO_STREAM_CPU_LIMIT = 0.0
 
-INSTALLED_APPS = INSTALLED_APPS + (
+INSTALLED_APPS += (
     'debug_toolbar',
 )
 
 DEBUG = True
-TEMPLATE_DEBUG = True
+for TEMPLATE_SETTINGS_BLOCK in TEMPLATES:
+    TEMPLATE_SETTINGS_BLOCK['OPTIONS']['debug'] = DEBUG
+
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
 CRISPY_FAIL_SILENTLY = not DEBUG
 
@@ -25,6 +27,7 @@ CRISPY_FAIL_SILENTLY = not DEBUG
 MIDDLEWARE_CLASSES = (
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 ) + MIDDLEWARE_CLASSES
+
 
 # Bypass the INTERNAL_IPS check for Debug Toolbar
 class internal_list(list):

--- a/roundware/settings/dev.py
+++ b/roundware/settings/dev.py
@@ -1,8 +1,4 @@
 from .common import *
-try:
-    from .local_settings import *
-except ImportError:
-    pass
 
 # Set Roundware API for internal calls to development environment
 API_URL = "http://127.0.0.1:8888/roundware/"
@@ -92,3 +88,8 @@ LOGGING['loggers'] = {
     #    'handlers': ['console'],
     # },
 }
+
+try:
+    from .local_settings import *
+except ImportError:
+    pass

--- a/roundware/urls.py
+++ b/roundware/urls.py
@@ -3,10 +3,11 @@
 
 from __future__ import unicode_literals
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 # Loading static files for debug mode
 from django.conf.urls.static import static
+from django.contrib.auth import views as auth_views
 
 from django.conf.urls import include
 from django.contrib import admin
@@ -15,15 +16,16 @@ from adminplus.sites import AdminSitePlus
 
 from roundware.rw import urls as rw_urls
 
+from roundware.rw import views as rw_views
+
 admin.site = AdminSitePlus()
 admin.sites.site = admin.site
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
-    url(r'^tools/asset-map$', 'rw.views.asset_map'),
-    url(r'^tools/listen-map$', 'rw.views.listen_map'),
-    url(r'^dashboard/$', 'rw.views.chart_views'),
+urlpatterns = [
+    url(r'^tools/asset-map$', rw_views.asset_map),
+    url(r'^tools/listen-map$', rw_views.listen_map),
+    url(r'^dashboard/$', rw_views.chart_views),
 
     # V1 DRF API
     url(r'^api/1/', include('roundware.api1.urls')),
@@ -31,20 +33,20 @@ urlpatterns = patterns(
     url(r'^api/2/', include('roundware.api2.urls')),
 
     # Use Django Admin login as overall login
-    url(r'^accounts/login/$', 'django.contrib.auth.views.login',
+    url(r'^accounts/login/$', auth_views.login,
         {'template_name': 'admin/login.html'}),
 
     url(r'^admin/', include(admin.site.urls)),
 
     url(r'^rw/', include(rw_urls)),
 
-) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 admin.site.site_header = 'Roundware Administration'
 
 if settings.DEBUG:
     import debug_toolbar
-    urlpatterns += patterns(
-        '',
+    urlpatterns += [
         url(r'^__debug__/', include(debug_toolbar.urls)),
-    )
+    ]
+    urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/roundwared/audiotrack.py
+++ b/roundwared/audiotrack.py
@@ -230,7 +230,8 @@ class AudioTrack:
             logger.debug("skip_ahead: no src_wav_file")
 
     def play_asset(self, asset_id):
-        logger.debug("AudioTrack play asset: " + str(asset_id))
+        logger.info("AudioTrack play asset: " + str(asset_id))
+        self.rc.remove_recording(asset_id)
         self.rc.add_recording(asset_id)
         self.skip_ahead()
 

--- a/roundwared/audiotrack.py
+++ b/roundwared/audiotrack.py
@@ -5,7 +5,7 @@
 #   when all audiotracks are finished (only happens
 #   when repeat is off)
 # TODO: Reimplement panning using a gst.Controller
-# TODO: Remove stero_pan from public interface
+# TODO: Remove stereo_pan from public interface
 
 from __future__ import unicode_literals
 import gobject
@@ -16,6 +16,7 @@ import gst
 import random
 import logging
 import os
+import time
 from roundwared import src_wav_file
 from roundwared import db
 from django.conf import settings
@@ -217,10 +218,13 @@ class AudioTrack:
             self.settings.minfadeouttime,
             self.settings.maxfadeouttime)
         if self.src_wav_file != None and not self.src_wav_file.fading:
+            logger.info("fading out for: " + str(fadeoutnsecs))
             self.src_wav_file.fade_out(fadeoutnsecs)
             # 1st arg is in milliseconds
             # 1000000000
             #gobject.timeout_add(fadeoutnsecs/gst.MSECOND, self.clean_up)
+            # wait until fade is complete and then clean-up
+            time.sleep(fadeoutnsecs / 1000000000)
             self.clean_up()
         else:
             logger.debug("skip_ahead: no src_wav_file")

--- a/roundwared/audiotrack.py
+++ b/roundwared/audiotrack.py
@@ -231,9 +231,13 @@ class AudioTrack:
 
     def play_asset(self, asset_id):
         logger.info("AudioTrack play asset: " + str(asset_id))
-        self.rc.remove_recording(asset_id)
-        self.rc.add_recording(asset_id)
+        try:
+            asset = Asset.objects.get(id=str(asset_id))
+            self.rc.remove_asset_from_rc(asset)
+            self.rc.add_asset_to_rc(asset)
         self.skip_ahead()
+        except Asset.DoesNotExist:
+            logger.error("Asset with ID %d does not exist." % asset_id)
 
     def set_track_metadata(self, metadata={}):
         """

--- a/roundwared/dbus_receive.py
+++ b/roundwared/dbus_receive.py
@@ -21,6 +21,10 @@ def add_signal_receiver(stream):
                 stream.heartbeat()
             elif operation == "skip_ahead":
                 stream.skip_ahead()
+            elif operation == "pause":
+                stream.pause()
+            elif operation == "resume":
+                stream.resume()
             elif operation == "play_asset":
                 request = json.loads(args)
                 stream.play_asset(request)

--- a/roundwared/recording_collection.py
+++ b/roundwared/recording_collection.py
@@ -158,9 +158,17 @@ class RecordingCollection:
 
     def add_recording(self, asset_id):
         self.lock.acquire()
-        logger.debug("asset id: %s " % asset_id)
+        logger.info("adding asset id to playlist_proximity: %s " % asset_id)
         a = Asset.objects.get(id=str(asset_id))
         self.playlist_proximity.append(a)
+        self.lock.release()
+
+    def remove_recording(self, asset_id):
+        self.lock.acquire()
+        logger.debug("removing asset id from playlist_proximity: %s " % asset_id)
+        a = Asset.objects.get(id=str(asset_id))
+        if a in self.playlist_proximity:
+            self.playlist_proximity.remove(a)
         self.lock.release()
 
     # Updates the collection of recordings according to a new listener

--- a/roundwared/recording_collection.py
+++ b/roundwared/recording_collection.py
@@ -37,7 +37,7 @@ class RecordingCollection:
         self.ordering = ordering
         self.project = Project.objects.get(id=int(self.request['project_id']))
 
-        # these are lists of model.Recording objects ie [rec1,rec2,etc]
+        # these are lists of model.Asset objects ie [rec1,rec2,etc]
         self.all = []
         # The main list of assets to play, in reverse order because it is a stack.
         self.playlist_proximity = []
@@ -156,19 +156,17 @@ class RecordingCollection:
 
         return None
 
-    def add_recording(self, asset_id):
+    def add_asset_to_rc(self, asset):
         self.lock.acquire()
-        logger.info("adding asset id to playlist_proximity: %s " % asset_id)
-        a = Asset.objects.get(id=str(asset_id))
-        self.playlist_proximity.append(a)
+        logger.info("adding asset id to playlist_proximity: %s " % asset.id)
+        self.playlist_proximity.append(asset)
         self.lock.release()
 
-    def remove_recording(self, asset_id):
+    def remove_asset_from_rc(self, asset):
         self.lock.acquire()
-        logger.debug("removing asset id from playlist_proximity: %s " % asset_id)
-        a = Asset.objects.get(id=str(asset_id))
-        if a in self.playlist_proximity:
-            self.playlist_proximity.remove(a)
+        logger.debug("removing asset id from playlist_proximity: %s " % asset.id)
+        if asset in self.playlist_proximity:
+            self.playlist_proximity.remove(asset)
         self.lock.release()
 
     # Updates the collection of recordings according to a new listener

--- a/roundwared/src_wav_file.py
+++ b/roundwared/src_wav_file.py
@@ -24,7 +24,7 @@ class SrcWavFile (gst.Bin):
 
         self.src_wav_file = gst.element_factory_make("filesrc")
         self.src_wav_file.set_property("location", uri)
-        self.decodebin = gst.element_factory_make("decodebin2")
+        self.wavparse = gst.element_factory_make("wavparse")
         self.audioconvert = gst.element_factory_make("audioconvert")
         self.audioresample = gst.element_factory_make("audioresample")
         self.audiopanorama = gst.element_factory_make("audiopanorama")
@@ -37,16 +37,16 @@ class SrcWavFile (gst.Bin):
         self.controller.set("volume", start + fadein, volume)
         self.controller.set("volume", start + duration - fadeout, volume)
         self.controller.set("volume", start + duration, 0.0)
-        self.add(self.src_wav_file, self.decodebin, self.audioconvert,
+        self.add(self.src_wav_file, self.wavparse, self.audioconvert,
                  self.audioresample, self.audiopanorama, self.volume)
-        gst.element_link_many(self.src_wav_file, self.decodebin)
+        gst.element_link_many(self.src_wav_file, self.wavparse)
         gst.element_link_many(self.audioconvert, self.audioresample,
                               self.audiopanorama, self.volume)
 
         def on_pad(comp, pad):
             convpad = self.audioconvert.get_compatible_pad(pad, pad.get_caps())
             pad.link(convpad)
-        self.decodebin.connect("pad-added", on_pad)
+        self.wavparse.connect("pad-added", on_pad)
         self.pad = self.volume.get_pad("src")
         self.ghostpad = gst.GhostPad("src", self.pad)
         self.add_pad(self.ghostpad)
@@ -54,7 +54,7 @@ class SrcWavFile (gst.Bin):
     def seek_to_start(self):
         if not self.already_seeked:
             self.already_seeked = True
-            self.decodebin.seek(
+            self.wavparse.seek(
                 1.0,
                 gst.Format(gst.FORMAT_TIME),
                 gst.SEEK_FLAG_ACCURATE,
@@ -65,7 +65,7 @@ class SrcWavFile (gst.Bin):
 
     def fade_out(self, nsecs):
         self.fading = True
-        pos_int = self.decodebin.query_position(gst.FORMAT_TIME, None)[0]
+        pos_int = self.wavparse.query_position(gst.FORMAT_TIME, None)[0]
         logger.debug("fade_out: got position: " + str(pos_int))
         self.controller.set_interpolation_mode(
             "volume", gst.INTERPOLATE_LINEAR)

--- a/roundwared/stream.py
+++ b/roundwared/stream.py
@@ -3,8 +3,10 @@
 
 from __future__ import unicode_literals
 import gobject
+
 gobject.threads_init()
 import pygst
+
 pygst.require("0.10")
 import gst
 import logging
@@ -20,6 +22,8 @@ from roundwared.recording_collection import RecordingCollection
 
 logger = logging.getLogger(__name__)
 
+STATE_PAUSED = 0
+STATE_PLAYING = 1
 
 class RoundStream:
     ######################################################################
@@ -43,6 +47,7 @@ class RoundStream:
         self.ordering = self.project.ordering
         # Keeps track of whether the stream has started playing audio.
         self.started = False
+        self.state = STATE_PAUSED
 
         logger.debug("Project radius: %d meters" % self.radius)
         if self.radius is None:
@@ -57,7 +62,7 @@ class RoundStream:
         self.icecast_admin = icecast2.Admin()
         self.heartbeat()
         self.recordingCollection = RecordingCollection(
-                self, request, self.radius, str(self.ordering))
+            self, request, self.radius, str(self.ordering))
 
     def start(self):
         logger.info("Session %s - Starting stream", self.sessionid)
@@ -88,6 +93,23 @@ class RoundStream:
         logger.debug("Skip ahead")
         for track in self.audiotracks:
             track.skip_ahead()
+
+    def pause(self):
+        logger.info("Session %s - Pausing stream", self.sessionid)
+        self.state = STATE_PAUSED
+
+        for track in self.audiotracks:
+            track.skip_ahead()
+
+    def resume(self):
+        logger.info("Session %s - Unpausing stream", self.sessionid)
+        self.state = STATE_PLAYING
+
+    def is_paused(self):
+        return self.state == STATE_PAUSED
+
+    def get_state(self):
+        return self.state
 
     # Sets the activity timestamp to right now.
     # The timestamp is used to detect
@@ -154,7 +176,6 @@ class RoundStream:
         self.watch_id = self.bus.connect("message", self.get_message)
         logger.debug("Success!")
 
-
     def add_source_to_adder(self, src_element):
         self.pipeline.add(src_element)
         srcpad = src_element.get_pad('src')
@@ -167,9 +188,9 @@ class RoundStream:
         # it'll be fine but test this.
         self.add_source_to_adder(BlankAudioSrc())
         self.gps_mixer = gpsmixer.GPSMixer(
-                {'latitude': self.request['latitude'],
-                 'longitude': self.request['longitude']},
-                self.project)
+            {'latitude': self.request['latitude'],
+             'longitude': self.request['longitude']},
+            self.project)
 
         self.add_source_to_adder(self.gps_mixer)
 
@@ -184,14 +205,14 @@ class RoundStream:
         logger.debug("Done adding audiotracks.")
         # TODO - ask if there is > 1 logical audiotrack per proj. for now, assume 1 to 1.
         # self.audiotracks = \
-            # map (lambda settings:
-            # AudioTrack(
-            # self,
-            # self.pipeline,
-            # self.adder,
-            # settings,
-            # self.recordingCollection),
-            #[c])
+        # map (lambda settings:
+        # AudioTrack(
+        # self,
+        # self.pipeline,
+        # self.adder,
+        # settings,
+        # self.recordingCollection),
+        # [c])
 
     # Gst Pipeline Bus Signal watcher starts audiotracks when the stream is
     # available for ouput.
@@ -216,6 +237,7 @@ class RoundStream:
                     and not self.started:
                 logger.debug("Stream for session %d has started." % self.sessionid)
                 self.started = True
+                self.state = STATE_PLAYING
                 gobject.timeout_add(settings.PING_INTERVAL, self.ping)
                 self.recordingCollection.start()
                 for track in self.audiotracks:
@@ -266,8 +288,7 @@ class RoundStream:
 
 # If there is no music this is needed to keep the stream not in
 # and EOS state while there is dead air.
-class BlankAudioSrc (gst.Bin):
-
+class BlankAudioSrc(gst.Bin):
     def __init__(self, wave=4):
         gst.Bin.__init__(self)
         audiotestsrc = gst.element_factory_make("audiotestsrc")
@@ -280,8 +301,7 @@ class BlankAudioSrc (gst.Bin):
         self.add_pad(ghost_pad)
 
 
-class RoundStreamSink (gst.Bin):
-
+class RoundStreamSink(gst.Bin):
     def __init__(self, sessionid, audio_format, bitrate):
         gst.Bin.__init__(self)
 

--- a/tests/roundware/api1/test_commands.py
+++ b/tests/roundware/api1/test_commands.py
@@ -23,7 +23,7 @@ from roundware.api1.commands import (check_for_single_audiotrack, get_asset_info
                                      get_available_assets)
 from roundware.api1 import commands
 from roundware.lib import api
-from roundware.lib.api import (request_stream, get_project_tags_old as get_project_tags, get_current_streaming_asset,
+from roundware.lib.api import (request_stream, get_project_tags_old as get_project_tags, get_currently_streaming_asset,
                                _get_current_streaming_asset, vote_asset)
 from roundwared import gpsmixer
 
@@ -115,7 +115,7 @@ class TestServer(RoundwaredTestCase):
         req.GET = {'session_id': self.session.id}
         track2 = mommy.make(Audiotrack, project=self.project1, id=2)
         with self.assertRaises(RoundException):
-            current = get_current_streaming_asset(req)
+            current = get_currently_streaming_asset(req)
             # delete extra track
             Audiotrack.objects.filter(id__exact=2).delete()
 
@@ -123,7 +123,7 @@ class TestServer(RoundwaredTestCase):
 
         req = FakeRequest()
         req.GET = {'session_id': self.session.id}
-        current = get_current_streaming_asset(req)
+        current = get_currently_streaming_asset(req)
         self.assertEquals('dict', type(current).__name__)
         self.assertEquals(2, current['asset_id'])
         self.assertEquals('2013-11-21T17:29:44.610672', current['start_time'])

--- a/tests/roundwared/test_audiotrack.py
+++ b/tests/roundwared/test_audiotrack.py
@@ -1,0 +1,59 @@
+from __future__ import unicode_literals
+from model_mommy import mommy
+
+from roundwared.recording_collection import RecordingCollection
+from .common import RoundwaredTestCase
+from roundware.rw.models import (Session, Asset, Project, Audiotrack)
+from roundwared.stream import RoundStream
+from roundwared.audiotrack import AudioTrack
+
+
+class TestRoundStream(RoundwaredTestCase):
+
+    """ Exercise methods and instances of RoundStream
+    """
+
+    def setUp(self):
+        super(type(self), TestRoundStream).setUp(self)
+
+        self.project1 = mommy.make(Project, name='Project One',
+                                   ordering='random', recording_radius=16)
+        self.session1 = mommy.make(Session, project=self.project1,
+                                   language=self.english)
+        self.req1 = {"session_id": self.session1.id,
+                     "project_id": self.project1.id}
+        self.asset1 = mommy.make(Asset, project=self.project1,
+                                 language=self.english,
+                                 tags=[self.tag1],
+                                 audiolength=2000)
+        self.asset2 = mommy.make(Asset, project=self.project1,
+                                 language=self.english,
+                                 tags=[self.tag1],
+                                 audiolength=2000)
+        self.audiotrack = mommy.make(Audiotrack, project=self.project1,
+                                     minvolume=1.0,
+                                     maxvolume=1.0,
+                                     minduration=10000000000.0,
+                                     maxduration=30000000000.0,
+                                     mindeadair=1000000000.0,
+                                     maxdeadair=3000000000.0,
+                                     minfadeintime=100000000.0,
+                                     maxfadeintime=500000000.0,
+                                     minfadeouttime=100000000.0,
+                                     maxfadeouttime=2000000000.0,
+                                     minpanpos=0.0,
+                                     maxpanpos=0.0,
+                                     minpanduration=5000000000.0,
+                                     maxpanduration=10000000000.0)
+
+    def test_play_asset(self):
+        req = self.req1
+        req["audio_stream_bitrate"] = '128'
+        stream = RoundStream(self.session1.id, 'ogg', req)
+        #TODO: Create real mocks for this
+        stream.pipeline = {}
+        stream.adder = {}
+        stream.add_audiotracks()
+        stream.audiotracks[0].play_asset(self.asset1.id)
+        self.assertEquals(stream.audiotracks[0].rc.playlist_proximity[0], self.asset1)
+        self.assertFalse(stream.audiotracks[0].play_asset(10))

--- a/tests/roundwared/test_recording_collection.py
+++ b/tests/roundwared/test_recording_collection.py
@@ -372,7 +372,7 @@ class TestRecordingCollection(RoundwaredTestCase):
             rc.update_request(req)
             self.assertEquals([self.asset1, self.asset2, self.asset3],
                               rc.playlist_proximity)
-            rc.add_recording(self.asset2.id)
+            rc.add_asset_to_rc(self.asset2)
             self.assertEquals([self.asset1, self.asset2, self.asset3,
                                self.asset2], rc.playlist_proximity)
 

--- a/tests/roundwared/test_stream.py
+++ b/tests/roundwared/test_stream.py
@@ -6,9 +6,8 @@ from model_mommy import mommy
 
 from .common import RoundwaredTestCase
 from roundware.rw.models import (UIGroup, Session, Tag, Asset, TagCategory,
-                                 UIItem, Project, LocalizedString)
+                                 UIItem, Project, LocalizedString, Audiotrack)
 from roundwared.stream import RoundStream
-
 
 class TestRoundStream(RoundwaredTestCase):
 
@@ -23,7 +22,9 @@ class TestRoundStream(RoundwaredTestCase):
         self.session1 = mommy.make(Session, project=self.project1,
                                    language=self.english)
         self.req1 = {"session_id": self.session1.id,
-                     "project_id": self.project1.id}
+                     "project_id": self.project1.id,
+                     "latitude":1.0,
+                     "longitude":1.0}
         self.asset1 = mommy.make(Asset, project=self.project1,
                                  language=self.english,
                                  tags=[self.tag1],
@@ -32,6 +33,21 @@ class TestRoundStream(RoundwaredTestCase):
                                  language=self.english,
                                  tags=[self.tag1],
                                  audiolength=2000)
+        self.audiotrack = mommy.make(Audiotrack, project=self.project1,
+                                     minvolume=1.0,
+                                     maxvolume=1.0,
+                                     minduration=10000000000.0,
+                                     maxduration=30000000000.0,
+                                     mindeadair=1000000000.0,
+                                     maxdeadair=3000000000.0,
+                                     minfadeintime=100000000.0,
+                                     maxfadeintime=500000000.0,
+                                     minfadeouttime=100000000.0,
+                                     maxfadeouttime=2000000000.0,
+                                     minpanpos=0.0,
+                                     maxpanpos=0.0,
+                                     minpanduration=5000000000.0,
+                                     maxpanduration=10000000000.0)
 
     def test_new_stream_has_recording_collection(self):
         """ Instantiate a new RoundStream.  Should have a RecordingCollection
@@ -75,3 +91,35 @@ class TestRoundStream(RoundwaredTestCase):
         stream = RoundStream(self.session1.id, 'ogg', req)
         admin = stream.icecast_admin
         self.assertEquals(admin.__class__.__name__, 'Admin')
+
+    def test_stream_get_state(self):
+        req = self.req1
+        req["audio_stream_bitrate"] = '128'
+        stream = RoundStream(self.session1.id, 'ogg', req)
+        self.assertEqual(stream.get_state(), 0)
+        stream.resume()
+        self.assertEqual(stream.get_state(), 1)
+
+    def test_pause_stream(self):
+        req = self.req1
+        req["audio_stream_bitrate"] = '128'
+        stream = RoundStream(self.session1.id, 'ogg', req)
+        stream.pause()
+        self.assertTrue(stream.is_paused())
+
+    def test_resume_stream(self):
+        req = self.req1
+        req["audio_stream_bitrate"] = '128'
+        stream = RoundStream(self.session1.id, 'ogg', req)
+        stream.resume()
+        self.assertFalse(stream.is_paused())
+
+    def test_add_audiotrack(self):
+        req = self.req1
+        req["audio_stream_bitrate"] = '128'
+        stream = RoundStream(self.session1.id, 'ogg', req)
+        stream.pipeline = {}
+        stream.adder = {}
+        self.assertEqual(len(stream.audiotracks), 0)
+        stream.add_audiotracks()
+        self.assertEqual(len(stream.audiotracks), 1)


### PR DESCRIPTION
This replaces PR #301. Functional changes are the same, but some erroneously committed changes removed, separated into smaller commits and rebased onto the newest `develop`.

Primary changes are:
- addition of pause/resume stream functionality
- fixes for play asset in stream, skip and replay functionality
- modernization of django code to avoid future deprecations

fixes #207