### PR TITLE
added api/2/streams/:id/isactive endpoint

### DIFF
--- a/roundware/api2/views.py
+++ b/roundware/api2/views.py
@@ -14,7 +14,7 @@ from roundware.api2.filters import (EventFilterSet, AssetFilterSet, ListeningHis
                                     UIItemFilterSet)
 from roundware.lib.api import (get_project_tags_new as get_project_tags, modify_stream, move_listener, heartbeat,
                                skip_ahead, pause, resume, add_asset_to_envelope, get_currently_streaming_asset,
-                               save_asset_from_request, vote_asset,
+                               save_asset_from_request, vote_asset, check_is_active,
                                vote_count_by_asset, log_event, play)
 from rest_framework import viewsets, status
 from rest_framework.permissions import IsAuthenticated, DjangoObjectPermissions
@@ -370,6 +370,19 @@ class StreamViewSet(viewsets.ViewSet):
                 'session_id': pk,
                 'asset_id': str(result.get('asset_id'))
             }))
+        except Exception as e:
+            return Response({"detail": str(e)},
+                            status.HTTP_400_BAD_REQUEST)
+
+    @detail_route(methods=['get'])
+    def isactive(self, request, pk=None):
+        try:
+            result = check_is_active(pk)
+            stream_id = int(pk)
+            return Response({
+                'stream_id': stream_id,
+                'active': result
+            })
         except Exception as e:
             return Response({"detail": str(e)},
                             status.HTTP_400_BAD_REQUEST)

--- a/roundware/lib/api.py
+++ b/roundware/lib/api.py
@@ -444,6 +444,12 @@ def check_for_single_audiotrack(session_id):
         ret = True
     return ret
 
+def check_is_active(session_id):
+    session = models.Session.objects.select_related('project').get(id=session_id)
+    audio_format = session.project.audio_format.upper()
+
+    return stream_exists(session_id, audio_format)
+
 
 # create_envelope
 # args: (operation, session_id, [tags])


### PR DESCRIPTION
Provides an easy way for a client to check if a stream is active on the server. Useful for web clients for which we don't want to implement `heartbeat` since browsers are more often left unattended than apps which would result in wasted bandwidth usage.

fixes #306