### PR TITLE
Update Vagrantfile to Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-dist: trusty
 language: python
 addons:
   postgresql: "9.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+dist: trusty
 language: python
 addons:
   postgresql: "9.3"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,9 +5,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  # Vagrant Cloud name for Ubuntu 14.04 LTS
-  config.vm.box = "ubuntu/trusty64"
-  config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box = "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-vagrant.box"
   config.vm.hostname = "roundware-server"
 
   # Configure Apache port 80 to forward to host 8080

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,7 +26,7 @@ USERNAME="roundware"
 # Use vagrant username/directories used when available.
 if [ "$FOUND_VAGRANT" = true ]; then
   # Change the user to the vagrant default.
-  USERNAME="vagrant"
+  USERNAME="ubuntu"
 fi
 
 # Set paths/directories

--- a/install.sh
+++ b/install.sh
@@ -23,8 +23,8 @@ USERNAME="roundware"
 
 # Use vagrant username/directories used when available.
 if [ "$FOUND_VAGRANT" = true ]; then
-  # Change the user to the vagrant default.
-  USERNAME="vagrant"
+  # Change the user to the vagrant default. (ubuntu, in the case of the 16.04.1 image)
+  USERNAME="ubuntu"
 
   # Create a symbolic link in the user's directory to the code
   ln -sfn /vagrant /home/$USERNAME/roundware-server
@@ -68,10 +68,23 @@ apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
 apache2 libapache2-mod-wsgi libav-tools mediainfo pacpl icecast2 \
 python-dev python-pip  python-dbus python-gst0.10 \
-gstreamer0.10-plugins-good gstreamer0.10-plugins-bad \
-gstreamer0.10-plugins-ugly gstreamer0.10-tools \
+gstreamer0.10-plugins-good \
+gstreamer0.10-tools \
 binutils libproj-dev gdal-bin libgdal-dev \
-postgresql-server-dev-9.3 postgresql-9.3-postgis-2.1
+postgresql-server-dev-9.5 postgresql-9.5-postgis-2.2 \
+libsidplay1v5
+
+# Download correct port of gstreamer-plugins-ugly/bad, for lame support
+# gstreamer0.10-plugins-ugly/bad were removed from Ubuntu 16.04 in favor of gstreamer1.0
+# via: https://launchpad.net/ubuntu/xenial/amd64/gstreamer0.10-plugins-ugly/0.10.19-2.1ubuntu4
+wget http://launchpadlibrarian.net/225705147/gstreamer0.10-plugins-ugly_0.10.19-2.1ubuntu4_amd64.deb
+
+# via: https://launchpad.net/ubuntu/xenial/amd64/gstreamer0.10-plugins-bad/0.10.23-8.1ubuntu3
+wget http://launchpadlibrarian.net/216017741/gstreamer0.10-plugins-bad_0.10.23-8.1ubuntu3_amd64.deb
+
+# install gstreamere-plugins-ugly/bad
+dpkg -i gstreamer0.10-plugins-ugly_0.10.19-2.1ubuntu4_amd64.deb
+dpkg -i gstreamer0.10-plugins-bad_0.10.23-8.1ubuntu3_amd64.deb
 
 # Install/upgrade virtualenv
 pip install -U virtualenv


### PR DESCRIPTION
Includes Postgres 9.5 with PostGIS 2.2.
to rebuilt Vagrant instance: vagrant halt && vagrant destroy && vagrant up.