### PR TITLE
Add listener range listening mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 group: deprecated-2017Q1
+dist: precise
 addons:
   postgresql: "9.3"
 python:

--- a/roundware/lib/api.py
+++ b/roundware/lib/api.py
@@ -344,6 +344,12 @@ def form_to_request(form):
             request[p] = float(form[p])
         else:
             request[p] = False
+
+    for p in ['listener_range_max']:
+        if p in form and form[p]:
+            request[p] = int(form[p])
+        else:
+            request[p] = None
     return request
 
 
@@ -357,8 +363,13 @@ def move_listener(request, context=None):
         # need to check for both until api/1 is deprecated
         form = request.GET or request.POST
     try:
+        if 'listener_range_max' in form:
+            logger.info("form listener_range_max = %s" % form['listener_range_max'])
         request = form_to_request(form)
+        if 'listener_range_max' in request:
+            logger.info("request listener_range_max = %s" % request['listener_range_max'])
         arg_hack = json.dumps(request)
+        logger.info("arg_hack = %s" % arg_hack)
         log_event("move_listener", int(form['session_id']), form)
         dbus_send.emit_stream_signal(
             int(form['session_id']), "move_listener", arg_hack)

--- a/roundware/lib/api.py
+++ b/roundware/lib/api.py
@@ -345,7 +345,7 @@ def form_to_request(form):
         else:
             request[p] = False
 
-    for p in ['listener_range_max']:
+    for p in ['listener_range_max', 'listener_range_min']:
         if p in form and form[p]:
             request[p] = int(form[p])
         else:

--- a/roundwared/recording_collection.py
+++ b/roundwared/recording_collection.py
@@ -260,12 +260,17 @@ class RecordingCollection:
         if 'latitude' in request and 'longitude' in request:
             # first, if listener_range_max parameter has been passed by user with value
             if 'listener_range_max' in request and request['listener_range_max'] is not None:
+                # assume listener_range_min is 0 unless passed in request
+                if 'listener_range_min' in request and request['listener_range_min'] is not None:
+                    lr_min = request['listener_range_min']
+                else:
+                    lr_min = 0
                 distance = gpsmixer.distance_in_meters(
                     request['latitude'], request['longitude'],
                     recording.latitude, recording.longitude)
-                if (distance <= request['listener_range_max']):
-                    logger.info("asset %s within listener_range_max" % recording.id)
-                return distance <= request['listener_range_max']
+                # if (distance <= request['listener_range_max'] and distance >= lr_min):
+                    # logger.info("asset %s within listener_range" % recording.id)
+                return (distance <= request['listener_range_max'] and distance >= lr_min)
             # then, if asset.shape exists see if listener is within shape
             elif recording.shape:
                 listener_location = Point(request['longitude'], request['latitude'], srid=recording.shape.srid)

--- a/tests/roundwared/test_recording_collection.py
+++ b/tests/roundwared/test_recording_collection.py
@@ -29,7 +29,8 @@ TEST_POLYGONS = {
 
 class TestRecordingCollection(APITestCase):
 
-    """ Exercise methods and instances of RecordingCollection
+    """
+    Exercise methods and instances of RecordingCollection
     """
 
     def setUp(self):
@@ -171,7 +172,8 @@ class TestRecordingCollection(APITestCase):
         self.assertEquals([], rc.all)
 
     def test_update_nearby_recordings_by_random(self):
-        """ test that we don't get the same order more than 8 out of
+        """
+        Test that we don't get the same order more than 8 out of
         10 tests.... not that scientific but probably reasonable
         """
         req = self.req1
@@ -217,7 +219,7 @@ class TestRecordingCollection(APITestCase):
 
     def test_get_recording_until_none_repeatmode_stop(self):
         """
-        test that we get the next playlist_proximity nearby recording, until there
+        Test that we get the next playlist_proximity nearby recording, until there
         are none left. project in stop repeatmode should then not
         return any recordings.
         """
@@ -236,7 +238,8 @@ class TestRecordingCollection(APITestCase):
             self.assertIsNone(rc.get_recording())
 
     def test_get_recording_until_none_then_move(self):
-        """ test that we get the next playlist_proximity nearby recording, until there
+        """
+        Test that we get the next playlist_proximity nearby recording, until there
         are none left. Then move away and back again. Wait for the ban time out
         and they should be available.
         """
@@ -276,7 +279,7 @@ class TestRecordingCollection(APITestCase):
 
     def test_global_listen_add_and_re_add_to_playlist(self):
         """
-        test for global listen projects that all assets are added
+        Test for global listen projects that all assets are added
         to playlist initially and then re-added with tag filtering
         only after BANNED_TIMEOUT_LIMIT has passed
         """
@@ -312,7 +315,8 @@ class TestRecordingCollection(APITestCase):
         self.session1.save()
 
     def test_get_recording_until_none_repeatmode_continuous(self):
-        """ test that we get the next playlist_proximity nearby recording, until there
+        """
+        Test that we get the next playlist_proximity nearby recording, until there
         are none left.  project in continuous repeatmode should then the
         first played recording.
         """
@@ -392,7 +396,8 @@ class TestRecordingCollection(APITestCase):
         self.project1.save()
 
     def test_add_recording(self):
-        """ add a specific asset id and it should show up in
+        """
+        Add a specific asset id and it should show up in
         playlist_proximity
         """
         # Request #2 has no lat/long to test that code
@@ -410,7 +415,8 @@ class TestRecordingCollection(APITestCase):
                                self.asset2], rc.playlist_proximity)
 
     def test_limit_asset_by_tag(self):
-        """ test that only tag1 assets are returned when request["tags"] is specified.
+        """
+        Test that only tag1 assets are returned when request["tags"] is specified.
         """
         req = self.req1
         stream = RoundStream(self.session1.id, 'ogg', req)
@@ -434,8 +440,9 @@ class TestRecordingCollection(APITestCase):
             self.assertEquals(None, rc.get_recording())
 
     def test_get_recording_geo_listen(self):
-        """ Disable geo-listen and confirm all recordings are available.
-            Enable geo-listen and confirm no recordings are available.
+        """
+        Disable geo-listen and confirm all recordings are available.
+        Enable geo-listen and confirm no recordings are available.
         """
         self.session1.geo_listen_enabled = False
         self.session1.save()
@@ -455,8 +462,9 @@ class TestRecordingCollection(APITestCase):
         self.assertEquals(None, rc.get_recording())
 
     def test_timed_asset_priority_true(self):
-        """ Test that _get_recording returns a proximity asset instead of a
-            timed asset when project.timed_asset_priority=True.
+        """
+        Test that _get_recording returns a proximity asset instead of a
+        timed asset when project.timed_asset_priority=True.
         """
         stream = RoundStream(self.session3.id, 'ogg', self.req3)
         rc = RecordingCollection(stream, self.req3, stream.radius, 'by_weight')
@@ -469,8 +477,9 @@ class TestRecordingCollection(APITestCase):
         self.assertEquals(self.asset5, rc.get_recording())
 
     def test_timed_asset_priority_false(self):
-        """ Test that _get_recording returns a proximity asset instead of a
-            timed asset when project.timed_asset_priority=False.
+        """
+        Test that _get_recording returns a proximity asset instead of a
+        timed asset when project.timed_asset_priority=False.
         """
         self.project3.timed_asset_priority = False
         self.project3.save()
@@ -486,8 +495,9 @@ class TestRecordingCollection(APITestCase):
         self.assertEquals(self.asset4, rc.get_recording())
 
     def test_timed_assets_filtered_by_tags(self):
-        """ Setup stream with no location assets and two timed assets.
-            Make sure only timed asset with proper tag is returned.
+        """
+        Setup stream with no location assets and two timed assets.
+        Make sure only timed asset with proper tag is returned.
         """
         stream = RoundStream(self.session3.id, 'ogg', self.req3)
         rc = RecordingCollection(stream, self.req3, stream.radius, 'by_weight')
@@ -503,8 +513,9 @@ class TestRecordingCollection(APITestCase):
         self.assertEquals(None, rc.get_recording())
 
     def test_timed_asset_ordering_by_weight(self):
-        """ Test that timed assets are ordered per the project.ordering
-            parameter (in this case 'by_weight').
+        """
+        Test that timed assets are ordered per the project.ordering
+        parameter (in this case 'by_weight').
         """
         stream = RoundStream(self.session3.id, 'ogg', self.req3)
         rc = RecordingCollection(stream, self.req3, stream.radius, 'by_weight')
@@ -520,8 +531,9 @@ class TestRecordingCollection(APITestCase):
         self.assertEquals(None, rc.get_recording())
 
     def test_asset_blocking(self):
-        """ Test that blocking an asset prevents it from being added
-            to the playlist_proximity
+        """
+        Test that blocking an asset prevents it from being added
+        to the playlist_proximity
         """
         # first create a user to perform the blocking
         # this should eventually be done 'globally' for this set of tests

--- a/tests/roundwared/test_recording_collection.py
+++ b/tests/roundwared/test_recording_collection.py
@@ -581,6 +581,44 @@ class TestRecordingCollection(APITestCase):
         self.assertEquals(self.asset2, rc.get_recording())
         self.assertEquals(None, rc.get_recording())
 
+    def test_listener_range_max(self):
+        """
+        Test that adding listener_range_max param to request adds previously
+        out of range asset to playlist_proximity
+        """
+        stream = RoundStream(self.session3.id, 'ogg', self.req3)
+        rc = RecordingCollection(stream, self.req3, stream.radius, 'by_weight')
+        # add listener_range_max param to request
+        self.req3['listener_range_max'] = 1000000
+        rc.move_listener(self.req3)
+        # Update the list of nearby recordings
+        rc.update_request(self.req3)
+        # verify that all assets within listener_range_max are included in playlist
+        self.assertEquals(self.asset5, rc.get_recording())
+        self.assertEquals(self.asset7, rc.get_recording())
+        self.assertEquals(self.asset8, rc.get_recording())
+        self.assertEquals(self.asset4, rc.get_recording())
+        self.assertEquals(None, rc.get_recording())
+
+    def test_listener_range_min(self):
+        """
+        Test that adding listener_range_min param to request prevents previously
+        in range asset from being added to playlist_proximity
+        """
+        stream = RoundStream(self.session3.id, 'ogg', self.req3)
+        rc = RecordingCollection(stream, self.req3, stream.radius, 'by_weight')
+        # add listener_range_max param to request
+        self.req3['listener_range_max'] = 1000000
+        self.req3['listener_range_min'] = 10000
+        rc.move_listener(self.req3)
+        # Update the list of nearby recordings
+        rc.update_request(self.req3)
+        # verify that all assets within listener_range_max are included in playlist
+        self.assertEquals(self.asset7, rc.get_recording())
+        self.assertEquals(self.asset8, rc.get_recording())
+        self.assertEquals(self.asset4, rc.get_recording())
+        self.assertEquals(None, rc.get_recording())
+
     def test_asset_shape(self):
         """
         Test that asset with asset.shape field defined is added to playlist_proximity


### PR DESCRIPTION
This mode is a hybrid between geo-listening and global listening in which a user is able to control max and min distance values from her current location in order to listen to content further away or closer by depending on her desires.

Soon, this will be combined with directional listening ( #341 ) and a new "motion-ui" for the client to create a totally new listening experience.

fixes #340 