### PR TITLE
pin django-cors-headers to a version that support django 1.9

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -36,7 +36,7 @@ psycopg2
 # geographic distance calculator utilities
 geopy
 # cors support to remove php layer
-django-cors-headers
+django-cors-headers==2.4.1  # 2.4.1 is the last version to support django 1.9
 # fiona is a useful tool for processing geographic files (ETL)
 fiona
 # geographic extensions for djangorestframework-gis


### PR DESCRIPTION
2.5 [dropped support for django 1.9](https://pypi.org/project/django-cors-headers/2.5.0/) and the project crashes with `cannot import name MiddlewareMixin` if you try to use it.

@hburgund 